### PR TITLE
Update benchmarking GHA

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           pixi r -e dev cargo --locked install cargo-criterion
           pixi r -e dev cargo --locked criterion --output-format bencher --benches 2>&1 | tee output.txt
+
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:


### PR DESCRIPTION
@castelao any reason we shouldn't use pixi + rust cache for the benchmarking GGHA? 

Not sure if that was intentional or if you were just going fast. 

If it was intentional, let me know and we can close this PR without merging.