### PR TITLE
Stop producing wheel for linux x86 32bits

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -19,8 +19,8 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-          - runner: ubuntu-22.04
-            target: x86
+          # - runner: ubuntu-22.04
+          #   target: x86
           # - runner: ubuntu-22.04
           #   target: aarch64
           # - runner: ubuntu-22.04


### PR DESCRIPTION
After the latest Zarrs update, it started failing linux 32bits. Since we probably don't have many systems with 32bits, let's stop producing this wheel for now and return to that later.