### PR TITLE
Move buffer to HashMap

### DIFF
--- a/crates/revrt/src/network/long_range/mod.rs
+++ b/crates/revrt/src/network/long_range/mod.rs
@@ -10,7 +10,7 @@ use crate::ArrayIndex;
 use swap::SwapStore;
 use utilities::{FinalizedBits, GridIndexer};
 
-const SPILL_BUFFER_ENTRY_BYTES: u64 = 24;
+const SPILL_BUFFER_ENTRY_BYTES: u64 = 32; // Spill buffer entry is 24 bytes, but we add a buffer for HashMap overhead
 const MAX_PQ_TO_FRONTIER_NODE_RATIO: usize = 2;
 
 #[derive(Clone, Debug)]
@@ -236,10 +236,10 @@ mod tests {
     #[test]
     fn spill_buffer_capacity_is_power_of_two_under_budget() {
         assert_eq!(spill_buffer_capacity(24), 0);
-        assert_eq!(spill_buffer_capacity(25), 1);
+        assert_eq!(spill_buffer_capacity(25), 0);
         assert_eq!(spill_buffer_capacity(48), 1);
-        assert_eq!(spill_buffer_capacity(49), 2);
-        assert_eq!(spill_buffer_capacity(1024), 32);
+        assert_eq!(spill_buffer_capacity(49), 1);
+        assert_eq!(spill_buffer_capacity(1024), 16);
     }
 
     #[test]

--- a/crates/revrt/src/network/long_range/mod.rs
+++ b/crates/revrt/src/network/long_range/mod.rs
@@ -10,7 +10,6 @@ use crate::ArrayIndex;
 use swap::SwapStore;
 use utilities::{FinalizedBits, GridIndexer};
 
-const SPILL_BUFFER_ENTRY_BYTES: u64 = 32; // Spill buffer entry is 24 bytes, but we add a buffer for HashMap overhead
 const MAX_PQ_TO_FRONTIER_NODE_RATIO: usize = 2;
 
 #[derive(Clone, Debug)]
@@ -203,7 +202,8 @@ fn compact_pq_set(best_node_costs: &HashMap<usize, u64>) -> BinaryHeap<NodeCost<
 }
 
 fn spill_buffer_capacity(memory_budget_bytes: u64) -> usize {
-    let max_entries = memory_budget_bytes.saturating_sub(1) / SPILL_BUFFER_ENTRY_BYTES;
+    let conservative_record_bytes = SwapStore::SPILL_RECORD_BYTES + 8; // Add 8 bytes for HashMap overhead per entry
+    let max_entries = memory_budget_bytes.saturating_sub(1) / conservative_record_bytes;
     let capped_entries = max_entries.min(usize::MAX as u64);
 
     if capped_entries == 0 {
@@ -236,10 +236,10 @@ mod tests {
     #[test]
     fn spill_buffer_capacity_is_power_of_two_under_budget() {
         assert_eq!(spill_buffer_capacity(24), 0);
-        assert_eq!(spill_buffer_capacity(25), 0);
+        assert_eq!(spill_buffer_capacity(25), 1);
         assert_eq!(spill_buffer_capacity(48), 1);
-        assert_eq!(spill_buffer_capacity(49), 1);
-        assert_eq!(spill_buffer_capacity(1024), 16);
+        assert_eq!(spill_buffer_capacity(49), 2);
+        assert_eq!(spill_buffer_capacity(1024), 32);
     }
 
     #[test]

--- a/crates/revrt/src/network/long_range/swap.rs
+++ b/crates/revrt/src/network/long_range/swap.rs
@@ -20,8 +20,6 @@ struct SpillRecord {
 }
 
 impl SpillRecord {
-    const RECORD_LEN: usize = 8 + 8;
-
     fn from_parts(cost: u64, parent_slot: Option<usize>) -> Self {
         let parent_slot = parent_slot
             .and_then(|slot| u64::try_from(slot).ok())
@@ -38,14 +36,14 @@ impl SpillRecord {
         }
     }
 
-    fn to_bytes(self) -> [u8; Self::RECORD_LEN] {
-        let mut out = [0_u8; Self::RECORD_LEN];
+    fn to_bytes(self) -> [u8; 16] {
+        let mut out = [0_u8; 16];
         out[0..8].copy_from_slice(&self.cost.to_le_bytes());
         out[8..16].copy_from_slice(&self.parent_slot.to_le_bytes());
         out
     }
 
-    fn from_bytes(bytes: [u8; Self::RECORD_LEN]) -> Self {
+    fn from_bytes(bytes: [u8; 16]) -> Self {
         let mut cost = [0_u8; 8];
         let mut parent_slot = [0_u8; 8];
         cost.copy_from_slice(&bytes[0..8]);
@@ -76,6 +74,8 @@ pub(super) struct SwapStore {
 }
 
 impl SwapStore {
+    pub(super) const SPILL_RECORD_BYTES: u64 = std::mem::size_of::<SpillRecord>() as u64;
+
     pub(super) fn new(write_buffer_capacity: usize) -> std::io::Result<Self> {
         let file = tempfile::Builder::new()
             .prefix("revrt-routing-swap-")
@@ -96,7 +96,7 @@ impl SwapStore {
     }
 
     fn slot_offset(slot: u64) -> std::io::Result<u64> {
-        slot.checked_mul(SpillRecord::RECORD_LEN as u64)
+        slot.checked_mul(16)
             .ok_or_else(|| std::io::Error::other("swap slot offset overflow"))
     }
 
@@ -147,7 +147,7 @@ impl SwapStore {
 
         let file = self.file.as_file_mut();
         file.seek(SeekFrom::Start(offset))?;
-        let mut bytes = [0_u8; SpillRecord::RECORD_LEN];
+        let mut bytes = [0_u8; 16];
         file.read_exact(&mut bytes)?;
         let record = SpillRecord::from_bytes(bytes);
         Ok((record.cost, record.parent_slot()))

--- a/crates/revrt/src/network/long_range/swap.rs
+++ b/crates/revrt/src/network/long_range/swap.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom, Write};
 
 use tempfile::NamedTempFile;
@@ -68,8 +69,8 @@ impl SpillRecord {
 pub(super) struct SwapStore {
     /// Temporary swap file that receives flushed records
     file: NamedTempFile,
-    /// In-memory queue of pending slot writes waiting to be flushed to disk
-    write_buffer: Vec<(u64, SpillRecord)>, // (slot, values)
+    /// Pending slot writes keyed by slot until they are flushed to disk
+    write_buffer: HashMap<u64, SpillRecord>,
     /// Maximum buffered writes before `write_slot` forces a flush
     write_buffer_capacity: usize,
 }
@@ -89,7 +90,7 @@ impl SwapStore {
         );
         Ok(Self {
             file,
-            write_buffer: Vec::with_capacity(write_buffer_capacity),
+            write_buffer: HashMap::with_capacity(write_buffer_capacity),
             write_buffer_capacity,
         })
     }
@@ -106,7 +107,7 @@ impl SwapStore {
     ) -> std::io::Result<()> {
         let slot = u64::try_from(slot).map_err(|_| std::io::Error::other("slot overflow"))?;
         self.write_buffer
-            .push((slot, SpillRecord::from_parts(record.0, record.1)));
+            .insert(slot, SpillRecord::from_parts(record.0, record.1));
 
         if self.write_buffer.len() >= self.write_buffer_capacity {
             self.flush()?;
@@ -122,7 +123,13 @@ impl SwapStore {
             // Only log if buffer is non-empty
             debug!("Flushing {} entries to disk", self.write_buffer.len());
         }
-        for (slot, record) in self.write_buffer.drain(..) {
+
+        let mut buffered_entries = self.write_buffer.drain().collect::<Vec<_>>();
+        if buffered_entries.len() > 1 {
+            buffered_entries.sort_unstable_by_key(|(slot, _)| *slot);
+        }
+
+        for (slot, record) in buffered_entries {
             let offset = Self::slot_offset(slot)?;
             let file = self.file.as_file_mut();
             file.seek(SeekFrom::Start(offset))?;
@@ -132,9 +139,12 @@ impl SwapStore {
     }
 
     pub(super) fn read_slot(&mut self, slot: usize) -> std::io::Result<(u64, Option<usize>)> {
-        self.flush()?;
-
         let slot = u64::try_from(slot).map_err(|_| std::io::Error::other("slot overflow"))?;
+
+        if let Some(record) = self.write_buffer.get(&slot).copied() {
+            return Ok((record.cost, record.parent_slot()));
+        }
+
         let offset = Self::slot_offset(slot)?;
 
         let file = self.file.as_file_mut();
@@ -180,6 +190,32 @@ mod tests {
 
         assert_eq!(restored.0, 11);
         assert_eq!(restored.1, Some(3));
+
+        swap.flush().unwrap();
+        let restored = swap.read_slot(4).unwrap();
+
+        assert_eq!(restored.0, 11);
+        assert_eq!(restored.1, Some(3));
+    }
+
+    #[test]
+    fn swap_store_read_prefers_pending_buffer() {
+        let mut swap = SwapStore::new(8).unwrap();
+
+        swap.write_slot(9, (5, Some(1))).unwrap();
+        swap.flush().unwrap();
+        swap.write_slot(9, (8, Some(7))).unwrap();
+
+        let restored = swap.read_slot(9).unwrap();
+
+        assert_eq!(restored.0, 8);
+        assert_eq!(restored.1, Some(7));
+
+        swap.flush().unwrap();
+        let restored = swap.read_slot(9).unwrap();
+
+        assert_eq!(restored.0, 8);
+        assert_eq!(restored.1, Some(7));
     }
 
     #[test]

--- a/crates/revrt/src/network/long_range/swap.rs
+++ b/crates/revrt/src/network/long_range/swap.rs
@@ -116,11 +116,9 @@ impl SwapStore {
     }
 
     pub(super) fn flush(&mut self) -> std::io::Result<()> {
-        if self.write_buffer.len() > 1 {
-            self.write_buffer.sort_unstable_by_key(|(slot, _)| *slot);
-        }
-        if !self.write_buffer.is_empty() {
-            // Buffer can be empty for repeated `read_slot` calls
+        if self.write_buffer.is_empty() {
+            return Ok(());
+        } else {
             // Only log if buffer is non-empty
             debug!("Flushing {} entries to disk", self.write_buffer.len());
         }

--- a/crates/revrt/src/network/long_range/swap.rs
+++ b/crates/revrt/src/network/long_range/swap.rs
@@ -119,10 +119,8 @@ impl SwapStore {
     pub(super) fn flush(&mut self) -> std::io::Result<()> {
         if self.write_buffer.is_empty() {
             return Ok(());
-        } else {
-            // Only log if buffer is non-empty
-            debug!("Flushing {} entries to disk", self.write_buffer.len());
         }
+        debug!("Flushing {} entries to disk", self.write_buffer.len());
 
         let mut buffered_entries = self.write_buffer.drain().collect::<Vec<_>>();
         if buffered_entries.len() > 1 {

--- a/crates/revrt/src/routing/mod.rs
+++ b/crates/revrt/src/routing/mod.rs
@@ -161,7 +161,7 @@ impl ParRouting {
                         // .map(|(route, total_cost)| Solution::new(route, unscaled_cost(total_cost)))
                         .collect();
                     let num_routes = routes.len();
-                    debug!("Finished computing {num_routes} to {end_inds:?}");
+                    debug!("Finished computing {num_routes} route(s) to {end_inds:?}");
                     sender.send((route_id, routes))
                 },
             );

--- a/revrt/routing/base.py
+++ b/revrt/routing/base.py
@@ -780,6 +780,7 @@ class BatchRouteProcessor:
 
         results_iter = iter(routing_results)
         num_complete = 0
+        ts = time.monotonic()
         while True:
             num_complete += 1
             try:
@@ -807,11 +808,13 @@ class BatchRouteProcessor:
                     attrs = self.route_attrs.get(attrs_key, self.default_attrs)
                     yield indices, optimized_objective, attrs
 
+                time_elapsed = f"{(time.monotonic() - ts) / 60:.4f} minute(s)"
                 logger.info(
-                    "%d/%d (%.2f%%) routes processed",
+                    "%d/%d (%.2f%%) route definitions processed in %s",
                     num_complete,
                     len(self.route_definitions),
                     (num_complete / len(self.route_definitions)) * 100,
+                    time_elapsed,
                 )
             except revrtRustError:  # pragma: no cover
                 logger.exception("Rust error when computing route")


### PR DESCRIPTION
We were previously using a `Vec` for the spill record buffer. This was a practical choice for memory purposes, but it meant that we had to spill records to disk before reading them back, and every `read_slot` operation would incur I/O overhead. This is a price we would probably be ok paying if `read_slot` is only ever used to reconstruct the final path, but some more advanced algorithms might use `read_slot` during routing itself to check the cost of a previously-recorded slot. To avoid major slowdown in these cases, we move to a HashMap-based buffer, which has O(1) lookup for slots that are still in memory. For scenarios where we have a lot of memory and/or the paths we are routing are short, this is a significant improvement since `read_slot` can just read directly from memory instead of checking a spilled record. In all other cases, the swap to a HashMap should have minor drawbacks (if any).