### PR TITLE
Add Bidirectional Dijkstras

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,7 +1796,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "revrt"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/revrt"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   "Guilherme Castelão <gpimenta@nlr.gov>",
   "Paul Pinchuk <Pavlo.Pinchuk@nlr.gov>",
@@ -17,7 +17,7 @@ categories = ["simulation"]
 keywords = ["NRL", "routing", "transmission", "reV", "reVX"]
 
 [workspace.dependencies]
-revrt = { version = "0.1.1", path = "crates/revrt" }
+revrt = { version = "0.1.2", path = "crates/revrt" }
 clap = { version = "4.5.48", features = ["derive", "cargo"] }
 criterion = { version = "0.8.1", features = ["html_reports"] }
 derive_builder = "0.20.2"

--- a/crates/revrt/src/dataset/mod.rs
+++ b/crates/revrt/src/dataset/mod.rs
@@ -317,8 +317,13 @@ impl Dataset {
                         );
                     } else {
                         self.calculate_chunk_cost(ci, cj);
-                        debug!("Recording chunk ({}, {}) as calculated", ci, cj);
                         chunk_idx[[ci as usize, cj as usize]] = true;
+                        debug!(
+                            "Recorded chunk ({}, {}) as calculated. Total number of computed chunks: {}",
+                            ci,
+                            cj,
+                            chunk_idx.iter().filter(|&&value| value).count()
+                        );
                     }
                     debug!("Released write lock for cost_chunk_idx ({}, {})", ci, cj);
                 }

--- a/crates/revrt/src/ffi/mod.rs
+++ b/crates/revrt/src/ffi/mod.rs
@@ -144,11 +144,13 @@ fn simplify_using_slopes(path: Vec<(f64, f64)>, slope_tolerance: f64) -> Vec<(f6
 ///     By default, `250,000,000` (250MB).
 /// algorithm : str, default="long_range_dijkstra"
 ///     Routing algorithm implementation to use. Supported values are
-///     ``"long_range_dijkstra"`` and ``"dijkstra"``. ``"dijkstra"`` is
-///     a faster implementation but does not respect the `mem_limit_bytes`
-///     input. Prefer the default ``"long_range_dijkstra"`` option unless
-///     you know for a fact that your route computations will not need
-///     much memory and speed is very important to you.
+///     ``"long_range_dijkstra"``,
+///     ``"bidirectional_long_range_dijkstra"``, and ``"dijkstra"``.
+///     ``"dijkstra"`` is a faster implementation but does not respect
+///     the `mem_limit_bytes` input. Prefer the default
+///     ``"long_range_dijkstra"`` option unless you know for a fact that
+///     your route computations will not need much memory and speed is
+///     very important to you.
 ///     By default, ``"long_range_dijkstra"``.
 ///
 /// Returns
@@ -214,11 +216,13 @@ fn find_paths(
 ///     By default, `250,000,000` (250MB).
 /// algorithm : str, default="long_range_dijkstra"
 ///     Routing algorithm implementation to use. Supported values are
-///     ``"long_range_dijkstra"`` and ``"dijkstra"``. ``"dijkstra"`` is
-///     a faster implementation but does not respect the `mem_limit_bytes`
-///     input. Prefer the default ``"long_range_dijkstra"`` option unless
-///     you know for a fact that your route computations will not need
-///     much memory and speed is very important to you.
+///     ``"long_range_dijkstra"``,
+///     ``"bidirectional_long_range_dijkstra"``, and ``"dijkstra"``.
+///     ``"dijkstra"`` is a faster implementation but does not respect
+///     the `mem_limit_bytes` input. Prefer the default
+///     ``"long_range_dijkstra"`` option unless you know for a fact that
+///     your route computations will not need much memory and speed is
+///     very important to you.
 ///     By default, ``"long_range_dijkstra"``.
 /// log_level : int, optional
 ///     Logging level for Rust tracing emitted to stderr. Roughly follows the

--- a/crates/revrt/src/ffi/mod.rs
+++ b/crates/revrt/src/ffi/mod.rs
@@ -4,7 +4,7 @@ mod simplify_path;
 use std::path::PathBuf;
 use std::sync::mpsc;
 
-use pyo3::exceptions::{PyException, PyIOError, PyValueError};
+use pyo3::exceptions::{PyException, PyIOError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 
 use crate::error::{Error, Result};
@@ -49,12 +49,16 @@ impl From<Error> for PyErr {
     fn from(err: Error) -> PyErr {
         match err {
             Error::IO(msg) => PyIOError::new_err(msg),
-            Error::ObjectStore(_) => todo!(),
+            object_store_error @ Error::ObjectStore(_) => {
+                PyIOError::new_err(object_store_error.to_string())
+            }
             Error::ZarrsArrayCreate(e) => PyIOError::new_err(e.to_string()),
             Error::ZarrsArray(e) => PyIOError::new_err(e.to_string()),
             Error::ZarrsStorage(e) => PyIOError::new_err(e.to_string()),
             Error::ZarrsGroupCreate(e) => PyIOError::new_err(e.to_string()),
-            Error::UnsupportedDataType(_, _) => todo!(),
+            invalid_data_type @ Error::UnsupportedDataType(_, _) => {
+                PyTypeError::new_err(invalid_data_type.to_string())
+            }
             Error::Undefined(msg) => revrtRustError::new_err(msg),
             invalid_dataset_shape @ Error::InvalidDatasetShape { .. } => {
                 PyValueError::new_err(invalid_dataset_shape.to_string())

--- a/crates/revrt/src/lib.rs
+++ b/crates/revrt/src/lib.rs
@@ -106,6 +106,7 @@ mod tests {
 
     #[test_case("dijkstra"; "dijkstra")]
     #[test_case("long-range-dijkstra"; "long-range")]
+    #[test_case("bidirectional-long-range-dijkstra"; "bidirectional-long-range")]
     #[allow(clippy::approx_constant)]
     // Due to truncation solution to handle f32 costs.
     fn minimalist(algorithm: &str) {
@@ -134,6 +135,11 @@ mod tests {
     #[test_case((1, 1), (2, 1), 2, 1., "long-range-dijkstra"; "step one cell down long-range")]
     #[test_case((1, 1), (2, 2), 2, 1.4142, "long-range-dijkstra"; "step one cell diagonally long-range")]
     #[test_case((1, 1), (2, 3), 3, 2.4142, "long-range-dijkstra"; "step diagonally and across long-range")]
+    #[test_case((1, 1), (1, 1), 1, 0., "bidirectional-long-range-dijkstra"; "no movement bidirectional long-range")]
+    #[test_case((1, 1), (1, 2), 2, 1., "bidirectional-long-range-dijkstra"; "step one cell to the side bidirectional long-range")]
+    #[test_case((1, 1), (2, 1), 2, 1., "bidirectional-long-range-dijkstra"; "step one cell down bidirectional long-range")]
+    #[test_case((1, 1), (2, 2), 2, 1.4142, "bidirectional-long-range-dijkstra"; "step one cell diagonally bidirectional long-range")]
+    #[test_case((1, 1), (2, 3), 3, 2.4142, "bidirectional-long-range-dijkstra"; "step diagonally and across bidirectional long-range")]
     fn basic_routing_point_to_point(
         (si, sj): (u64, u64),
         (ei, ej): (u64, u64),
@@ -156,6 +162,7 @@ mod tests {
 
     #[test_case((1, 1), vec![(1, 4), (3, 1), (4, 4)], (3, 1), 3, 2., "dijkstra"; "different cost endpoints dijkstra")]
     #[test_case((1, 1), vec![(1, 4), (3, 1), (4, 4)], (3, 1), 3, 2., "long-range-dijkstra"; "different cost endpoints long-range")]
+    #[test_case((1, 1), vec![(1, 4), (3, 1), (4, 4)], (3, 1), 3, 2., "bidirectional-long-range-dijkstra"; "different cost endpoints bidirectional long-range")]
     fn basic_routing_one_point_to_many(
         (si, sj): (u64, u64),
         endpoints: Vec<(u64, u64)>,
@@ -191,6 +198,9 @@ mod tests {
     #[test_case((1, 1), vec![(1, 3), (3, 1)], 1., "long-range-dijkstra"; "horizontal and vertical long-range")]
     #[test_case((3, 3), vec![(3, 5), (1, 1), (3, 1)], 1., "long-range-dijkstra"; "horizontal long-range")]
     #[test_case((3, 3), vec![(5, 3), (5, 5), (1, 3)], 1., "long-range-dijkstra"; "vertical long-range")]
+    #[test_case((1, 1), vec![(1, 3), (3, 1)], 1., "bidirectional-long-range-dijkstra"; "horizontal and vertical bidirectional long-range")]
+    #[test_case((3, 3), vec![(3, 5), (1, 1), (3, 1)], 1., "bidirectional-long-range-dijkstra"; "horizontal bidirectional long-range")]
+    #[test_case((3, 3), vec![(5, 3), (5, 5), (1, 3)], 1., "bidirectional-long-range-dijkstra"; "vertical bidirectional long-range")]
     fn routing_one_point_to_many_same_cost_and_length(
         (si, sj): (u64, u64),
         endpoints: Vec<(u64, u64)>,
@@ -222,6 +232,7 @@ mod tests {
 
     #[test_case("dijkstra"; "dijkstra")]
     #[test_case("long-range-dijkstra"; "long-range")]
+    #[test_case("bidirectional-long-range-dijkstra"; "bidirectional-long-range")]
     #[allow(clippy::approx_constant)]
     // Due to truncation solution to handle f32 costs.
     fn routing_many_to_many(algorithm: &str) {
@@ -257,6 +268,7 @@ mod tests {
 
     #[test_case("dijkstra"; "dijkstra")]
     #[test_case("long-range-dijkstra"; "long-range")]
+    #[test_case("bidirectional-long-range-dijkstra"; "bidirectional-long-range")]
     fn routing_many_to_one(algorithm: &str) {
         let store_path = dataset::samples::uniform_cost_zarr(1, 8, 8, 1, 4, 4, 1.0);
         let cost_function =
@@ -277,6 +289,7 @@ mod tests {
 
     #[test_case("dijkstra"; "dijkstra")]
     #[test_case("long-range-dijkstra"; "long-range")]
+    #[test_case("bidirectional-long-range-dijkstra"; "bidirectional-long-range")]
     fn test_routing_along_boundary(algorithm: &str) {
         use dataset::samples;
 

--- a/crates/revrt/src/network/cost.rs
+++ b/crates/revrt/src/network/cost.rs
@@ -28,26 +28,27 @@ impl<I> PartialOrd for NodeCost<I, u32> {
         Some(self.cmp(other))
     }
 }
-
 impl<I> PartialOrd for NodeCost<I, u64> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
-
 impl<I> PartialOrd for NodeCost<I, i32> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
-
 impl<I> PartialOrd for NodeCost<I, i64> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
-
 impl<I> PartialOrd for NodeCost<I, f32> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<I> PartialOrd for NodeCost<I, f64> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
@@ -98,6 +99,14 @@ impl<I> Ord for NodeCost<I, i64> {
     }
 }
 impl<I> Ord for NodeCost<I, f32> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match other.estimated_cost.total_cmp(&self.estimated_cost) {
+            Ordering::Equal => other.cost.total_cmp(&self.cost),
+            ordering => ordering,
+        }
+    }
+}
+impl<I> Ord for NodeCost<I, f64> {
     fn cmp(&self, other: &Self) -> Ordering {
         match other.estimated_cost.total_cmp(&self.estimated_cost) {
             Ordering::Equal => other.cost.total_cmp(&self.cost),

--- a/crates/revrt/src/network/long_range/mod.rs
+++ b/crates/revrt/src/network/long_range/mod.rs
@@ -19,12 +19,6 @@ pub(crate) struct FinalizedNode {
     cost: u64,
 }
 
-impl FinalizedNode {
-    fn route(&self, state: &mut FrontierOnlySearchState) -> Option<Vec<ArrayIndex>> {
-        state.reconstruct_path_to(self.slot)
-    }
-}
-
 #[derive(Debug)]
 /// Tracks the mutable state for a search that spills finalized nodes to disk.
 ///
@@ -125,77 +119,6 @@ impl FrontierOnlySearchState {
         None
     }
 
-    pub(crate) fn finalize_route(&mut self, node: FinalizedNode) -> Option<(Vec<ArrayIndex>, u64)> {
-        let cost = node.cost;
-        let route = node.route(self)?;
-        Some((route, cost))
-    }
-
-    pub(crate) fn has_frontier(&mut self) -> bool {
-        self.peek_next_cost().is_some()
-    }
-
-    pub(crate) fn peek_next_cost(&mut self) -> Option<u64> {
-        while let Some(candidate) = self.pq.peek() {
-            if self.finalized_bits.contains(candidate.index) {
-                self.pq.pop();
-                continue;
-            }
-
-            return Some(candidate.cost);
-        }
-
-        None
-    }
-
-    pub(crate) fn known_cost(&mut self, slot: usize) -> Option<u64> {
-        if let Some(cost) = self.best_node_costs.get(&slot).copied() {
-            return Some(cost);
-        }
-
-        if self.finalized_bits.contains(slot) {
-            debug!(
-                "Looking for known cost in swap! Buffer contains slot {}: {}",
-                slot,
-                self.swap.slot_in_buffer(slot)
-            );
-            return self.swap.read_slot(slot).ok().map(|(cost, _)| cost);
-        }
-
-        None
-    }
-
-    pub(crate) fn reconstruct_known_path_to(
-        &mut self,
-        goal_slot: usize,
-    ) -> Option<Vec<ArrayIndex>> {
-        let mut path = Vec::new();
-        let mut current_slot = Some(goal_slot);
-
-        while let Some(slot) = current_slot {
-            path.push(self.grid.index_of(slot));
-            if self.roots.contains(&slot) {
-                break;
-            }
-
-            if let Some(parent) = self.parents.get(&slot).copied() {
-                current_slot = Some(parent);
-                continue;
-            }
-
-            if self.finalized_bits.contains(slot) {
-                let (_, parent) = self.swap.read_slot(slot).ok()?;
-                current_slot = parent;
-                continue;
-            }
-
-            return None;
-        }
-
-        path.reverse();
-        Some(path)
-    }
-
     pub(crate) fn add_successors<C, IN>(
         &mut self,
         node: &FinalizedNode,
@@ -269,6 +192,70 @@ impl FrontierOnlySearchState {
         None
     }
 
+    pub(crate) fn peek_next_cost(&mut self) -> Option<u64> {
+        while let Some(candidate) = self.pq.peek() {
+            if self.finalized_bits.contains(candidate.index) {
+                self.pq.pop();
+                continue;
+            }
+
+            return Some(candidate.cost);
+        }
+
+        None
+    }
+
+    pub(crate) fn known_cost(&mut self, slot: usize) -> Option<u64> {
+        if let Some(cost) = self.best_node_costs.get(&slot).copied() {
+            return Some(cost);
+        }
+
+        if self.finalized_bits.contains(slot) {
+            debug!(
+                "Looking for known cost in swap! Buffer contains slot {}: {}",
+                slot,
+                self.swap.slot_in_buffer(slot)
+            );
+            return self.swap.read_slot(slot).ok().map(|(cost, _)| cost);
+        }
+
+        None
+    }
+
+    pub(crate) fn finalize_route(&mut self, node: FinalizedNode) -> Option<(Vec<ArrayIndex>, u64)> {
+        let cost = node.cost;
+        let route = self.reconstruct_path_to(node.slot)?;
+        Some((route, cost))
+    }
+
+    pub(crate) fn reconstruct_path_to(&mut self, goal_slot: usize) -> Option<Vec<ArrayIndex>> {
+        let mut path = Vec::new();
+        let mut current_slot = Some(goal_slot);
+
+        while let Some(slot) = current_slot {
+            path.push(self.grid.index_of(slot));
+            if self.roots.contains(&slot) {
+                break;
+            }
+
+            if let Some(parent) = self.parents.get(&slot).copied() {
+                current_slot = Some(parent);
+                continue;
+            }
+
+            if self.finalized_bits.contains(slot) {
+                let (_, parent) = self.swap.read_slot(slot).ok()?;
+                current_slot = parent;
+                continue;
+            }
+
+            return None;
+        }
+
+        path.reverse();
+        Some(path)
+    }
+
     pub(crate) fn enforce_memory_budget(&mut self) -> Option<()> {
         if self.pq.len() > self.best_node_costs.len() * MAX_PQ_TO_FRONTIER_NODE_RATIO {
             debug!(
@@ -283,10 +270,6 @@ impl FrontierOnlySearchState {
         }
 
         Some(())
-    }
-
-    fn reconstruct_path_to(&mut self, goal_slot: usize) -> Option<Vec<ArrayIndex>> {
-        self.reconstruct_known_path_to(goal_slot)
     }
 }
 
@@ -320,19 +303,19 @@ impl BidirectionalSearchState {
         C: Copy,
         u64: From<C>,
     {
-        while self.forward.has_frontier() && self.backward.has_frontier() {
-            if self.should_terminate() {
+        loop {
+            let Some(forward_cost) = self.forward.peek_next_cost() else {
+                break;
+            };
+            let Some(backward_cost) = self.backward.peek_next_cost() else {
+                break;
+            };
+
+            if self.found_best_cost(forward_cost, backward_cost) {
                 break;
             }
 
-            let expand_forward = match (
-                self.forward.peek_next_cost(),
-                self.backward.peek_next_cost(),
-            ) {
-                (Some(forward_cost), Some(backward_cost)) => forward_cost <= backward_cost,
-                _ => break,
-            };
-
+            let expand_forward = forward_cost <= backward_cost;
             self.expand_direction(expand_forward, &mut successors)?;
         }
 
@@ -395,16 +378,9 @@ impl BidirectionalSearchState {
         }
     }
 
-    fn should_terminate(&mut self) -> bool {
+    fn found_best_cost(&mut self, forward_cost: u64, backward_cost: u64) -> bool {
         let Some((_, best_cost)) = self.best_path else {
             return false;
-        };
-
-        let Some(forward_cost) = self.forward.peek_next_cost() else {
-            return true;
-        };
-        let Some(backward_cost) = self.backward.peek_next_cost() else {
-            return true;
         };
 
         forward_cost.saturating_add(backward_cost) >= best_cost
@@ -412,8 +388,8 @@ impl BidirectionalSearchState {
 
     fn reconstruct_route(&mut self, meeting_slot: usize) -> Option<Vec<ArrayIndex>> {
         debug!("Goal node found at meeting slot {}", meeting_slot);
-        let mut forward = self.forward.reconstruct_known_path_to(meeting_slot)?;
-        let mut backward = self.backward.reconstruct_known_path_to(meeting_slot)?;
+        let mut forward = self.forward.reconstruct_path_to(meeting_slot)?;
+        let mut backward = self.backward.reconstruct_path_to(meeting_slot)?;
         backward.reverse();
         forward.extend(backward.into_iter().skip(1));
         Some(forward)
@@ -535,7 +511,7 @@ mod tests {
     }
 
     #[test]
-    fn reconstruct_known_path_works_for_frontier_nodes() {
+    fn reconstruct_path_works_for_frontier_nodes() {
         let start = ArrayIndex::new(0, 0);
         let mut state = FrontierOnlySearchState::new(&start, 2_000, (3, 3)).unwrap();
         let node = state.pop_next_node().unwrap();
@@ -544,7 +520,7 @@ mod tests {
             .unwrap();
 
         let slot = state.grid.slot_of(&ArrayIndex::new(0, 1)).unwrap();
-        let path = state.reconstruct_known_path_to(slot).unwrap();
+        let path = state.reconstruct_path_to(slot).unwrap();
 
         assert_eq!(path, vec![ArrayIndex::new(0, 0), ArrayIndex::new(0, 1)]);
     }

--- a/crates/revrt/src/network/long_range/mod.rs
+++ b/crates/revrt/src/network/long_range/mod.rs
@@ -154,6 +154,11 @@ impl FrontierOnlySearchState {
         }
 
         if self.finalized_bits.contains(slot) {
+            debug!(
+                "Looking for known cost in swap! Buffer contains slot {}: {}",
+                slot,
+                self.swap.slot_in_buffer(slot)
+            );
             return self.swap.read_slot(slot).ok().map(|(cost, _)| cost);
         }
 
@@ -406,6 +411,7 @@ impl BidirectionalSearchState {
     }
 
     fn reconstruct_route(&mut self, meeting_slot: usize) -> Option<Vec<ArrayIndex>> {
+        debug!("Goal node found at meeting slot {}", meeting_slot);
         let mut forward = self.forward.reconstruct_known_path_to(meeting_slot)?;
         let mut backward = self.backward.reconstruct_known_path_to(meeting_slot)?;
         backward.reverse();

--- a/crates/revrt/src/network/long_range/mod.rs
+++ b/crates/revrt/src/network/long_range/mod.rs
@@ -84,14 +84,6 @@ impl FrontierOnlySearchState {
                 continue;
             }
 
-            let Some(current_best) = self.best_node_costs.get(&index).copied() else {
-                continue;
-            };
-
-            if cost != current_best {
-                continue;
-            }
-
             let array_index = self.grid.index_of(index);
             let parent_slot = self.parents.remove(&index);
             self.best_node_costs.remove(&index);

--- a/crates/revrt/src/network/long_range/mod.rs
+++ b/crates/revrt/src/network/long_range/mod.rs
@@ -1,7 +1,7 @@
 pub(super) mod swap;
 pub(super) mod utilities;
 
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 
 use tracing::debug;
 
@@ -33,6 +33,7 @@ impl FinalizedNode {
 /// written to the swap store for later path reconstruction.
 pub(crate) struct FrontierOnlySearchState {
     grid: GridIndexer,
+    roots: HashSet<usize>,
     // Frontier nodes ordered by estimated total cost.
     pq: BinaryHeap<NodeCost<usize, u64>>,
     // Cheapest known cost for each frontier node still tracked in memory.
@@ -55,11 +56,19 @@ impl FrontierOnlySearchState {
         memory_budget_bytes: u64,
         grid_shape: (u64, u64),
     ) -> Option<Self> {
+        Self::new_many(std::slice::from_ref(start), memory_budget_bytes, grid_shape)
+    }
+
+    pub(crate) fn new_many(
+        starts: &[ArrayIndex],
+        memory_budget_bytes: u64,
+        grid_shape: (u64, u64),
+    ) -> Option<Self> {
         let grid = GridIndexer::new(grid_shape.0, grid_shape.1)?;
-        let start_slot = grid.slot_of(start)?;
 
         let mut state = Self {
             grid,
+            roots: HashSet::new(),
             pq: BinaryHeap::new(),
             best_node_costs: HashMap::new(),
             parents: HashMap::new(),
@@ -68,13 +77,28 @@ impl FrontierOnlySearchState {
             num_nodes_checked: 0,
         };
 
-        state.best_node_costs.insert(start_slot, 0);
-        state.pq.push(NodeCost {
-            index: start_slot,
-            cost: 0,
-            estimated_cost: 0,
-        });
-        Some(state)
+        for start in starts {
+            let Some(start_slot) = state.grid.slot_of(start) else {
+                continue;
+            };
+
+            if !state.roots.insert(start_slot) {
+                continue;
+            }
+
+            state.best_node_costs.insert(start_slot, 0);
+            state.pq.push(NodeCost {
+                index: start_slot,
+                cost: 0,
+                estimated_cost: 0,
+            });
+        }
+
+        if state.roots.is_empty() {
+            None
+        } else {
+            Some(state)
+        }
     }
 
     pub(crate) fn pop_next_node(&mut self) -> Option<FinalizedNode> {
@@ -107,6 +131,66 @@ impl FrontierOnlySearchState {
         Some((route, cost))
     }
 
+    pub(crate) fn has_frontier(&mut self) -> bool {
+        self.peek_next_cost().is_some()
+    }
+
+    pub(crate) fn peek_next_cost(&mut self) -> Option<u64> {
+        while let Some(candidate) = self.pq.peek() {
+            if self.finalized_bits.contains(candidate.index) {
+                self.pq.pop();
+                continue;
+            }
+
+            return Some(candidate.cost);
+        }
+
+        None
+    }
+
+    pub(crate) fn known_cost(&mut self, slot: usize) -> Option<u64> {
+        if let Some(cost) = self.best_node_costs.get(&slot).copied() {
+            return Some(cost);
+        }
+
+        if self.finalized_bits.contains(slot) {
+            return self.swap.read_slot(slot).ok().map(|(cost, _)| cost);
+        }
+
+        None
+    }
+
+    pub(crate) fn reconstruct_known_path_to(
+        &mut self,
+        goal_slot: usize,
+    ) -> Option<Vec<ArrayIndex>> {
+        let mut path = Vec::new();
+        let mut current_slot = Some(goal_slot);
+
+        while let Some(slot) = current_slot {
+            path.push(self.grid.index_of(slot));
+            if self.roots.contains(&slot) {
+                break;
+            }
+
+            if let Some(parent) = self.parents.get(&slot).copied() {
+                current_slot = Some(parent);
+                continue;
+            }
+
+            if self.finalized_bits.contains(slot) {
+                let (_, parent) = self.swap.read_slot(slot).ok()?;
+                current_slot = parent;
+                continue;
+            }
+
+            return None;
+        }
+
+        path.reverse();
+        Some(path)
+    }
+
     pub(crate) fn add_successors<C, IN>(
         &mut self,
         node: &FinalizedNode,
@@ -117,8 +201,27 @@ impl FrontierOnlySearchState {
         C: Copy,
         u64: From<C>,
     {
+        self.add_successors_tracking(node, successors, |_, _| {})
+    }
+
+    pub(crate) fn add_successors_tracking<C, IN, F>(
+        &mut self,
+        node: &FinalizedNode,
+        successors: IN,
+        mut on_update: F,
+    ) -> Option<()>
+    where
+        IN: IntoIterator<Item = (ArrayIndex, C)>,
+        C: Copy,
+        F: FnMut(usize, u64),
+        u64: From<C>,
+    {
         for (neighbor, edge_cost) in successors {
-            self.add_neighbor(node.slot, node.cost, &neighbor, edge_cost);
+            if let Some((slot, cost)) =
+                self.add_neighbor(node.slot, node.cost, &neighbor, edge_cost)
+            {
+                on_update(slot, cost);
+            }
         }
         self.enforce_memory_budget()
     }
@@ -129,16 +232,15 @@ impl FrontierOnlySearchState {
         from_cost: u64,
         neighbor: &ArrayIndex,
         edge_cost: C,
-    ) where
+    ) -> Option<(usize, u64)>
+    where
         C: Copy,
         u64: From<C>,
     {
-        let Some(neighbor_slot) = self.grid.slot_of(neighbor) else {
-            return;
-        };
+        let neighbor_slot = self.grid.slot_of(neighbor)?;
 
         if self.finalized_bits.contains(neighbor_slot) {
-            return;
+            return None;
         }
 
         let next_cost = from_cost.saturating_add(u64::from(edge_cost));
@@ -156,7 +258,10 @@ impl FrontierOnlySearchState {
                 cost: next_cost,
                 estimated_cost: next_cost,
             });
+            return Some((neighbor_slot, next_cost));
         }
+
+        None
     }
 
     pub(crate) fn enforce_memory_budget(&mut self) -> Option<()> {
@@ -176,17 +281,136 @@ impl FrontierOnlySearchState {
     }
 
     fn reconstruct_path_to(&mut self, goal_slot: usize) -> Option<Vec<ArrayIndex>> {
-        let mut path = Vec::new();
-        let mut current_slot = Some(goal_slot);
+        self.reconstruct_known_path_to(goal_slot)
+    }
+}
 
-        while let Some(slot) = current_slot {
-            path.push(self.grid.index_of(slot));
-            let (_, parent) = self.swap.read_slot(slot).ok()?;
-            current_slot = parent;
+#[derive(Debug)]
+pub(crate) struct BidirectionalSearchState {
+    forward: FrontierOnlySearchState,
+    backward: FrontierOnlySearchState,
+    best_path: Option<(usize, u64)>,
+}
+
+impl BidirectionalSearchState {
+    pub(crate) fn new(
+        start: &ArrayIndex,
+        goals: &[ArrayIndex],
+        memory_budget_bytes: u64,
+        grid_shape: (u64, u64),
+    ) -> Option<Self> {
+        let per_direction_budget = (memory_budget_bytes / 2).max(1);
+
+        Some(Self {
+            forward: FrontierOnlySearchState::new(start, per_direction_budget, grid_shape)?,
+            backward: FrontierOnlySearchState::new_many(goals, per_direction_budget, grid_shape)?,
+            best_path: None,
+        })
+    }
+
+    pub(crate) fn run<C, FN, IN>(&mut self, mut successors: FN) -> Option<(Vec<ArrayIndex>, u64)>
+    where
+        FN: FnMut(&ArrayIndex) -> IN,
+        IN: IntoIterator<Item = (ArrayIndex, C)>,
+        C: Copy,
+        u64: From<C>,
+    {
+        while self.forward.has_frontier() && self.backward.has_frontier() {
+            if self.should_terminate() {
+                break;
+            }
+
+            let expand_forward = match (
+                self.forward.peek_next_cost(),
+                self.backward.peek_next_cost(),
+            ) {
+                (Some(forward_cost), Some(backward_cost)) => forward_cost <= backward_cost,
+                _ => break,
+            };
+
+            self.expand_direction(expand_forward, &mut successors)?;
         }
 
-        path.reverse();
-        Some(path)
+        let (meeting_slot, cost) = self.best_path?;
+        let route = self.reconstruct_route(meeting_slot)?;
+        Some((route, cost))
+    }
+
+    fn expand_direction<C, FN, IN>(
+        &mut self,
+        expand_forward: bool,
+        successors: &mut FN,
+    ) -> Option<()>
+    where
+        FN: FnMut(&ArrayIndex) -> IN,
+        IN: IntoIterator<Item = (ArrayIndex, C)>,
+        C: Copy,
+        u64: From<C>,
+    {
+        let mut candidates = Vec::new();
+
+        {
+            let (current, other) = if expand_forward {
+                (&mut self.forward, &mut self.backward)
+            } else {
+                (&mut self.backward, &mut self.forward)
+            };
+
+            let node = match current.pop_next_node() {
+                Some(node) => node,
+                None => return Some(()),
+            };
+
+            if let Some(other_cost) = other.known_cost(node.slot) {
+                candidates.push((node.slot, node.cost.saturating_add(other_cost)));
+            }
+
+            current.add_successors_tracking(
+                &node,
+                successors(&node.array_index),
+                |slot, cost| {
+                    if let Some(other_cost) = other.known_cost(slot) {
+                        candidates.push((slot, cost.saturating_add(other_cost)));
+                    }
+                },
+            )?;
+        }
+
+        for (slot, total_cost) in candidates {
+            self.record_candidate(slot, total_cost);
+        }
+
+        Some(())
+    }
+
+    fn record_candidate(&mut self, slot: usize, total_cost: u64) {
+        match self.best_path {
+            Some((_, best_cost)) if best_cost <= total_cost => {}
+            _ => self.best_path = Some((slot, total_cost)),
+        }
+    }
+
+    fn should_terminate(&mut self) -> bool {
+        let Some((_, best_cost)) = self.best_path else {
+            return false;
+        };
+
+        let Some(forward_cost) = self.forward.peek_next_cost() else {
+            return true;
+        };
+        let Some(backward_cost) = self.backward.peek_next_cost() else {
+            return true;
+        };
+
+        forward_cost.saturating_add(backward_cost) >= best_cost
+    }
+
+    fn reconstruct_route(&mut self, meeting_slot: usize) -> Option<Vec<ArrayIndex>> {
+        let mut forward = self.forward.reconstruct_known_path_to(meeting_slot)?;
+        let mut backward = self.backward.reconstruct_known_path_to(meeting_slot)?;
+        backward.reverse();
+        forward.extend(backward.into_iter().skip(1));
+        Some(forward)
     }
 }
 
@@ -287,5 +511,65 @@ mod tests {
         });
 
         assert!(ans.is_none());
+    }
+
+    #[test]
+    fn multi_source_state_skips_invalid_roots() {
+        let starts = vec![
+            ArrayIndex::new(0, 0),
+            ArrayIndex::new(0, 0),
+            ArrayIndex::new(999, 999),
+        ];
+        let mut state = FrontierOnlySearchState::new_many(&starts, 2_000, (3, 3)).unwrap();
+
+        let node = state.pop_next_node().unwrap();
+
+        assert_eq!(node.array_index, ArrayIndex::new(0, 0));
+        assert!(state.pop_next_node().is_none());
+    }
+
+    #[test]
+    fn reconstruct_known_path_works_for_frontier_nodes() {
+        let start = ArrayIndex::new(0, 0);
+        let mut state = FrontierOnlySearchState::new(&start, 2_000, (3, 3)).unwrap();
+        let node = state.pop_next_node().unwrap();
+        state
+            .add_successors(&node, vec![(ArrayIndex::new(0, 1), 1_u64)])
+            .unwrap();
+
+        let slot = state.grid.slot_of(&ArrayIndex::new(0, 1)).unwrap();
+        let path = state.reconstruct_known_path_to(slot).unwrap();
+
+        assert_eq!(path, vec![ArrayIndex::new(0, 0), ArrayIndex::new(0, 1)]);
+    }
+
+    #[test]
+    fn bidirectional_search_merges_forward_and_backward_paths() {
+        let start = ArrayIndex::new(0, 0);
+        let goals = vec![ArrayIndex::new(2, 2)];
+        let mut state = BidirectionalSearchState::new(&start, &goals, 2_000, (3, 3)).unwrap();
+
+        let (route, cost) = state
+            .run(|p| {
+                let mut out = Vec::new();
+                if p.i > 0 {
+                    out.push((ArrayIndex::new(p.i - 1, p.j), 1_u64));
+                }
+                if p.i < 2 {
+                    out.push((ArrayIndex::new(p.i + 1, p.j), 1_u64));
+                }
+                if p.j > 0 {
+                    out.push((ArrayIndex::new(p.i, p.j - 1), 1_u64));
+                }
+                if p.j < 2 {
+                    out.push((ArrayIndex::new(p.i, p.j + 1), 1_u64));
+                }
+                out
+            })
+            .unwrap();
+
+        assert_eq!(cost, 4);
+        assert_eq!(route.first(), Some(&start));
+        assert_eq!(route.last(), Some(&ArrayIndex::new(2, 2)));
     }
 }

--- a/crates/revrt/src/network/long_range/mod.rs
+++ b/crates/revrt/src/network/long_range/mod.rs
@@ -275,8 +275,11 @@ impl FrontierOnlySearchState {
 
 #[derive(Debug)]
 pub(crate) struct BidirectionalSearchState {
-    forward: FrontierOnlySearchState,
-    backward: FrontierOnlySearchState,
+    // The forward frontier tracks paths from the start node(s).
+    forward_frontier: FrontierOnlySearchState,
+    // The backward frontier tracks paths from all goals simultaneously.
+    backward_frontier: FrontierOnlySearchState,
+    // Best candidate path found so far, represented as the meeting slot and total cost.
     best_path: Option<(usize, u64)>,
 }
 
@@ -290,8 +293,16 @@ impl BidirectionalSearchState {
         let per_direction_budget = (memory_budget_bytes / 2).max(1);
 
         Some(Self {
-            forward: FrontierOnlySearchState::new(start, per_direction_budget, grid_shape)?,
-            backward: FrontierOnlySearchState::new_many(goals, per_direction_budget, grid_shape)?,
+            forward_frontier: FrontierOnlySearchState::new(
+                start,
+                per_direction_budget,
+                grid_shape,
+            )?,
+            backward_frontier: FrontierOnlySearchState::new_many(
+                goals,
+                per_direction_budget,
+                grid_shape,
+            )?,
             best_path: None,
         })
     }
@@ -304,10 +315,10 @@ impl BidirectionalSearchState {
         u64: From<C>,
     {
         loop {
-            let Some(forward_cost) = self.forward.peek_next_cost() else {
+            let Some(forward_cost) = self.forward_frontier.peek_next_cost() else {
                 break;
             };
-            let Some(backward_cost) = self.backward.peek_next_cost() else {
+            let Some(backward_cost) = self.backward_frontier.peek_next_cost() else {
                 break;
             };
 
@@ -338,26 +349,26 @@ impl BidirectionalSearchState {
         let mut candidates = Vec::new();
 
         {
-            let (current, other) = if expand_forward {
-                (&mut self.forward, &mut self.backward)
+            let (current_frontier, other_frontier) = if expand_forward {
+                (&mut self.forward_frontier, &mut self.backward_frontier)
             } else {
-                (&mut self.backward, &mut self.forward)
+                (&mut self.backward_frontier, &mut self.forward_frontier)
             };
 
-            let node = match current.pop_next_node() {
+            let node = match current_frontier.pop_next_node() {
                 Some(node) => node,
                 None => return Some(()),
             };
 
-            if let Some(other_cost) = other.known_cost(node.slot) {
+            if let Some(other_cost) = other_frontier.known_cost(node.slot) {
                 candidates.push((node.slot, node.cost.saturating_add(other_cost)));
             }
 
-            current.add_successors_tracking(
+            current_frontier.add_successors_tracking(
                 &node,
                 successors(&node.array_index),
                 |slot, cost| {
-                    if let Some(other_cost) = other.known_cost(slot) {
+                    if let Some(other_cost) = other_frontier.known_cost(slot) {
                         candidates.push((slot, cost.saturating_add(other_cost)));
                     }
                 },
@@ -388,8 +399,8 @@ impl BidirectionalSearchState {
 
     fn reconstruct_route(&mut self, meeting_slot: usize) -> Option<Vec<ArrayIndex>> {
         debug!("Goal node found at meeting slot {}", meeting_slot);
-        let mut forward = self.forward.reconstruct_path_to(meeting_slot)?;
-        let mut backward = self.backward.reconstruct_path_to(meeting_slot)?;
+        let mut forward = self.forward_frontier.reconstruct_path_to(meeting_slot)?;
+        let mut backward = self.backward_frontier.reconstruct_path_to(meeting_slot)?;
         backward.reverse();
         forward.extend(backward.into_iter().skip(1));
         Some(forward)

--- a/crates/revrt/src/network/long_range/swap.rs
+++ b/crates/revrt/src/network/long_range/swap.rs
@@ -152,6 +152,14 @@ impl SwapStore {
         let record = SpillRecord::from_bytes(bytes);
         Ok((record.cost, record.parent_slot()))
     }
+
+    pub(super) fn slot_in_buffer(&self, slot: usize) -> bool {
+        let slot = match u64::try_from(slot) {
+            Ok(slot) => slot,
+            Err(_) => return false,
+        };
+        self.write_buffer.contains_key(&slot)
+    }
 }
 
 impl Drop for SwapStore {

--- a/crates/revrt/src/routing/algorithm.rs
+++ b/crates/revrt/src/routing/algorithm.rs
@@ -27,6 +27,7 @@ pub(super) enum AlgorithmType {
     // Astar,
     Dijkstra,
     LongRangeDijkstra,
+    BidirectionalLongRangeDijkstra,
 }
 
 impl FromStr for AlgorithmType {
@@ -36,9 +37,14 @@ impl FromStr for AlgorithmType {
         match value.trim().to_ascii_lowercase().replace('-', "_").as_str() {
             "dijkstra" => Ok(Self::Dijkstra),
             "long_range_dijkstra" => Ok(Self::LongRangeDijkstra),
+            "bidirectional_long_range_dijkstra" => Ok(Self::BidirectionalLongRangeDijkstra),
             _ => Err(Error::InvalidAlgorithm {
                 value: value.to_string(),
-                allowed: &["dijkstra", "long_range_dijkstra"],
+                allowed: &[
+                    "dijkstra",
+                    "long_range_dijkstra",
+                    "bidirectional_long_range_dijkstra",
+                ],
             }),
         }
     }
@@ -97,6 +103,28 @@ impl Algorithm {
         }
     }
 
+    pub(super) fn new_bidirectional_long_range(per_worker_memory_budget_bytes: u64) -> Self {
+        if per_worker_memory_budget_bytes < MIN_MEMORY_BUDGET_MB * 1024 * 1024 {
+            warn!(
+                "Bidirectional long-range Dijkstra per-worker memory budget smaller than the {}MB minimum! Setting to {}MB...",
+                MIN_MEMORY_BUDGET_MB, MIN_MEMORY_BUDGET_MB
+            );
+            Self {
+                algorithm_type: AlgorithmType::BidirectionalLongRangeDijkstra,
+                per_worker_memory_budget_bytes: Some(MIN_MEMORY_BUDGET_MB * 1024 * 1024),
+            }
+        } else {
+            debug!(
+                "Bidirectional long-range Dijkstra per-worker memory budget set to {}MB",
+                per_worker_memory_budget_bytes / (1024 * 1024)
+            );
+            Self {
+                algorithm_type: AlgorithmType::BidirectionalLongRangeDijkstra,
+                per_worker_memory_budget_bytes: Some(per_worker_memory_budget_bytes),
+            }
+        }
+    }
+
     pub(super) fn from_selection(
         algorithm: AlgorithmType,
         per_worker_memory_budget_bytes: u64,
@@ -106,6 +134,9 @@ impl Algorithm {
             AlgorithmType::LongRangeDijkstra => {
                 Self::new_long_range(per_worker_memory_budget_bytes)
             }
+            AlgorithmType::BidirectionalLongRangeDijkstra => {
+                Self::new_bidirectional_long_range(per_worker_memory_budget_bytes)
+            }
         }
     }
 
@@ -113,6 +144,7 @@ impl Algorithm {
     pub(super) fn compute<C, FN, IN, FH, FS>(
         &self,
         start: &ArrayIndex,
+        goals: &[ArrayIndex],
         successors: FN,
         heuristic: Option<FH>,
         success: FS,
@@ -146,6 +178,18 @@ impl Algorithm {
                     grid_shape,
                 )
             }
+            AlgorithmType::BidirectionalLongRangeDijkstra => {
+                let per_worker_memory_budget_bytes = self
+                    .per_worker_memory_budget_bytes
+                    .expect("Memory budget not set for bidirectional long-range Dijkstra");
+                long_range::bidirectional_long_range_dijkstra(
+                    start,
+                    goals,
+                    successors,
+                    per_worker_memory_budget_bytes,
+                    grid_shape,
+                )
+            }
         };
 
         ans.map(|(route, total_cost)| {
@@ -171,6 +215,10 @@ mod tests {
             AlgorithmType::from_str("long_range_dijkstra").unwrap(),
             AlgorithmType::LongRangeDijkstra
         );
+        assert_eq!(
+            AlgorithmType::from_str("bidirectional_long_range_dijkstra").unwrap(),
+            AlgorithmType::BidirectionalLongRangeDijkstra
+        );
     }
 
     #[test]
@@ -182,6 +230,10 @@ mod tests {
         assert_eq!(
             AlgorithmType::from_str(" LONG-RANGE-DIJKSTRA ").unwrap(),
             AlgorithmType::LongRangeDijkstra
+        );
+        assert_eq!(
+            AlgorithmType::from_str(" bidirectional-long-range-dijkstra ").unwrap(),
+            AlgorithmType::BidirectionalLongRangeDijkstra
         );
     }
 

--- a/crates/revrt/src/routing/long_range.rs
+++ b/crates/revrt/src/routing/long_range.rs
@@ -7,7 +7,7 @@ use num_traits::Zero;
 use tracing::debug;
 
 use crate::ArrayIndex;
-use crate::network::long_range::FrontierOnlySearchState;
+use crate::network::long_range::{BidirectionalSearchState, FrontierOnlySearchState};
 
 pub(super) fn long_range_dijkstra<C, FN, IN, FS>(
     start: &ArrayIndex,
@@ -45,6 +45,40 @@ where
     }
 
     None
+}
+
+pub(super) fn bidirectional_long_range_dijkstra<C, FN, IN>(
+    start: &ArrayIndex,
+    goals: &[ArrayIndex],
+    successors: FN,
+    memory_budget_bytes: u64,
+    grid_shape: (u64, u64),
+) -> Option<(Vec<ArrayIndex>, C)>
+where
+    C: Zero + Ord + Copy,
+    FN: FnMut(&ArrayIndex) -> IN,
+    IN: IntoIterator<Item = (ArrayIndex, C)>,
+    u64: From<C>,
+    C: From<u64>,
+{
+    debug!(
+        "Starting bidirectional long-range Dijkstra with memory budget of {} bytes",
+        memory_budget_bytes
+    );
+
+    if goals.is_empty() {
+        return None;
+    }
+
+    if goals.iter().any(|goal| goal == start) {
+        return Some((vec![start.clone()], C::zero()));
+    }
+
+    let mut state = BidirectionalSearchState::new(start, goals, memory_budget_bytes, grid_shape)?;
+
+    state
+        .run(successors)
+        .map(|(route, cost)| (route, C::from(cost)))
 }
 
 #[cfg(test)]
@@ -88,6 +122,49 @@ mod tests {
             |_p: &ArrayIndex| Vec::<(ArrayIndex, u64)>::new(),
             |_p| false,
             1024,
+            (1, 1),
+        );
+
+        assert!(ans.is_none());
+    }
+
+    #[test]
+    fn bidirectional_bounded_finds_shortest_path_to_any_goal() {
+        let start = ArrayIndex::new(0, 0);
+        let goals = vec![ArrayIndex::new(2, 2), ArrayIndex::new(0, 2)];
+
+        let ans = bidirectional_long_range_dijkstra(
+            &start,
+            &goals,
+            |p: &ArrayIndex| {
+                let mut out = Vec::new();
+                if p.i < 2 {
+                    out.push((ArrayIndex::new(p.i + 1, p.j), 1_u64));
+                }
+                if p.j < 2 {
+                    out.push((ArrayIndex::new(p.i, p.j + 1), 1_u64));
+                }
+                out
+            },
+            2 * 1024 * 1024,
+            (3, 3),
+        )
+        .unwrap();
+
+        assert_eq!(ans.1, 2_u64);
+        assert_eq!(ans.0.first(), Some(&start));
+        assert_eq!(ans.0.last(), Some(&ArrayIndex::new(0, 2)));
+    }
+
+    #[test]
+    fn bidirectional_bounded_rejects_missing_goals() {
+        let start = ArrayIndex::new(0, 0);
+
+        let ans = bidirectional_long_range_dijkstra(
+            &start,
+            &[],
+            |_p: &ArrayIndex| Vec::<(ArrayIndex, u64)>::new(),
+            2 * 1024 * 1024,
             (1, 1),
         );
 

--- a/crates/revrt/src/routing/mod.rs
+++ b/crates/revrt/src/routing/mod.rs
@@ -41,6 +41,7 @@ impl Routing {
             .filter_map(|s| {
                 self.algorithm.compute(
                     s,
+                    &end,
                     |p| self.scenario.successors(p),
                     None::<fn(&ArrayIndex) -> u64>,
                     |p| end.contains(p),
@@ -145,8 +146,10 @@ impl ParRouting {
                     let routes: RevrtRoutingSolutions = start_inds
                         .into_par_iter()
                         .filter_map(|s| {
+                            let end_ind_vec: Vec<_> = end_inds.iter().cloned().collect();
                             algorithm.compute(
                                 &s,
+                                &end_ind_vec,
                                 |p| scenario.successors(p),
                                 None::<fn(&ArrayIndex) -> u64>,
                                 |p| end_inds.contains(p),
@@ -161,7 +164,7 @@ impl ParRouting {
                         // .map(|(route, total_cost)| Solution::new(route, unscaled_cost(total_cost)))
                         .collect();
                     let num_routes = routes.len();
-                    debug!("Finished computing {num_routes} to {end_inds:?}");
+                    debug!("Finished computing {num_routes} route(s) to {end_inds:?}");
                     sender.send((route_id, routes))
                 },
             );

--- a/crates/revrt/src/routing/scenario.rs
+++ b/crates/revrt/src/routing/scenario.rs
@@ -48,15 +48,6 @@ impl Scenario {
     }
 
     /// Determine the successors of a position.
-    ///
-    /// ToDo:
-    /// - Handle the edges of the array.
-    /// - Weight the cost. Remember that the cost is for a side,
-    ///   thus a diagonal move has to calculate consider the longer
-    ///   distance.
-    /// - Add starting cell cost by adding a is_start parameter and
-    ///   passing it down to the get_3x3 function so that it can add
-    ///   the center pixel to all successor cost values
     pub(super) fn successors(&self, position: &ArrayIndex) -> Vec<(ArrayIndex, u64)> {
         let neighbors = self.get_3x3(position);
         let neighbors = neighbors

--- a/pixi.lock
+++ b/pixi.lock
@@ -17570,8 +17570,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: nlr-revrt
-  version: 0.4.1
-  sha256: 889ed2550bde459d936ae1af8d078bf45d416c65065a8c1e606928c24d0ac23c
+  version: 0.5.0
+  sha256: f4d73973c42cadf38446a13b2e67e4919ccb2cc324250020eb621585d3e75587
   requires_dist:
   - affine>=2.4.0,<3
   - dask>=2026.3.0,<2027

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "NLR-reVRt"
-version = "0.4.1"
+version = "0.5.0"
 description = "National Laboratory of the Rockies' (NLR's) Transmission for reV tool"
 readme = "README.rst"
 authors = [

--- a/revrt/routing/base.py
+++ b/revrt/routing/base.py
@@ -408,7 +408,7 @@ class CharacterizedLayer:
             layer_data = da.asarray(layer_data)
 
         if self.is_length_invariant:
-            layer_cost = da.sum(layer_data[1:])
+            layer_cost = da.sum(layer_data)
         else:
             layer_cost = da.sum(layer_data * lens)
 
@@ -498,9 +498,8 @@ class RouteMetrics:
             y=xr.DataArray(rows, dims="points"),
             x=xr.DataArray(cols, dims="points"),
         )
-        invariant_cost = da.sum(inv_cell_costs[1:])
+        invariant_cost = da.sum(inv_cell_costs)
 
-        # Multiple distance travel through cell by cost and sum it!
         return (cost + invariant_cost).compute()
 
     @property

--- a/revrt/routing/base.py
+++ b/revrt/routing/base.py
@@ -42,7 +42,7 @@ class RoutingScenario:
         cost_multiplier_layer=None,
         cost_multiplier_scalar=1,
         ignore_invalid_costs=True,
-        algorithm="long_range_dijkstra",
+        algorithm="bidirectional_long_range_dijkstra",
     ):
         """
 
@@ -65,15 +65,16 @@ class RoutingScenario:
             Scalar multiplier applied to the final cost surface.
         ignore_invalid_costs : bool, optional
             Flag indicating whether non-positive costs block traversal.
-        algorithm : str, default="long_range_dijkstra"
+        algorithm : str, default="bidirectional_long_range_dijkstra"
             Routing algorithm implementation to use. Supported values
-            are ``"long_range_dijkstra"`` and ``"dijkstra"``.
-            ``"dijkstra"`` is a faster implementation but does not
-            respect the memory limit. Prefer the default
+            are ``"long_range_dijkstra"``,
+            ``"bidirectional_long_range_dijkstra"``, and
+            ``"dijkstra"``. ``"dijkstra"`` is a faster implementation
+            but does not respect the memory limit. Prefer the default
             ``"long_range_dijkstra"`` option unless you know for a fact
             that your route computations will not need much memory and
             speed is very important to you.
-            By default, ``"long_range_dijkstra"``.
+            By default, ``"bidirectional_long_range_dijkstra"``.
         """
         self.cost_fpath = cost_fpath
         self.cost_layers = cost_layers

--- a/revrt/routing/base.py
+++ b/revrt/routing/base.py
@@ -815,7 +815,7 @@ class BatchRouteProcessor:
                     attrs = self.route_attrs.get(attrs_key, self.default_attrs)
                     yield indices, optimized_objective, attrs
 
-                time_elapsed = f"{(time.monotonic() - ts) / 60:.4f} minute(s)"
+                time_elapsed = f"{(time.monotonic() - ts) / 60:.2f} minute(s)"
                 logger.info(
                     "%d/%d (%.2f%%) route definitions processed in %s",
                     num_complete,

--- a/revrt/routing/base.py
+++ b/revrt/routing/base.py
@@ -869,18 +869,32 @@ class BatchRouteProcessor:
         if not points or not self.routing_scenario.ignore_invalid_costs:
             return points
 
+        all_invalid_points_msg = (
+            f"None of the end points have a valid cost (must be > 0): {points}"
+        )
+
         rows, cols = np.array(points).T
         costs = self.routing_layers.cost.isel(
             y=xr.DataArray(rows, dims="points"),
             x=xr.DataArray(cols, dims="points"),
         )
 
-        if not np.any(costs.compute() > 0):
+        cost_values = costs.compute()
+        bad_point_inds = np.where(np.isnan(cost_values) | (cost_values <= 0))[
+            0
+        ]
+        invalid_points = {points[i] for i in bad_point_inds}
+        if invalid_points:
             msg = (
-                f"None of the end points have a valid cost (must be > 0): "
-                f"{points}"
+                f"One or more of the end points have an invalid cost "
+                f"(must be > 0): {invalid_points}\n"
+                "Dropping these from consideration..."
             )
-            raise revrtLeastCostPathNotFoundError(msg)
+            warn(msg, revrtWarning)
+            points = [p for p in points if p not in invalid_points]
+
+        if not points:
+            raise revrtLeastCostPathNotFoundError(all_invalid_points_msg)
 
         return points
 

--- a/revrt/routing/cli/point_to_feature.py
+++ b/revrt/routing/cli/point_to_feature.py
@@ -194,7 +194,7 @@ def compute_lcp_routes(  # noqa: PLR0913, PLR0917
     save_paths=False,
     ignore_invalid_costs=False,
     connection_identifier_column="end_feat_id",
-    algorithm="long_range_dijkstra",
+    algorithm="bidirectional_long_range_dijkstra",
     memory_utilization_limit=0.9,
     system_mem_limit_gb=5,
     _split_params=None,
@@ -423,14 +423,16 @@ def compute_lcp_routes(  # noqa: PLR0913, PLR0917
         `route_table` input to map points to features. If a column name
         is given that does not exist in the data, an error will be
         raised. By default, ``"end_feat_id"``.
-    algorithm : str, default="long_range_dijkstra"
+    algorithm : str, default="bidirectional_long_range_dijkstra"
         Routing algorithm implementation to use. Supported values are
-        ``"long_range_dijkstra"`` and ``"dijkstra"``. ``"dijkstra"`` is
-        a faster implementation but does not respect the memory
-        utilization limit input. Prefer the default
+        ``"long_range_dijkstra"``,
+        ``"bidirectional_long_range_dijkstra"``, and ``"dijkstra"``.
+        ``"dijkstra"`` is a faster implementation but does not respect
+        the memory utilization limit input. Prefer the default
         ``"long_range_dijkstra"`` option unless you know for a fact that
         your route computations will not need much memory and speed is
-        very important to you. By default, ``"long_range_dijkstra"``.
+        very important to you.
+        By default, ``"bidirectional_long_range_dijkstra"``.
     memory_utilization_limit : float, default=0.9
         Fraction of system memory to utilize for routing. Should be a
         value between 0 and 1. By default, ``0.9``.

--- a/revrt/routing/cli/point_to_point.py
+++ b/revrt/routing/cli/point_to_point.py
@@ -98,7 +98,7 @@ def compute_lcp_routes(  # noqa: PLR0913, PLR0917
     memory_utilization_limit=0.9,
     system_mem_limit_gb=5,
     _split_params=None,
-    algorithm="long_range_dijkstra",
+    algorithm="bidirectional_long_range_dijkstra",
 ):
     r"""Run least-cost path routing for pairs of points
 
@@ -306,14 +306,16 @@ def compute_lcp_routes(  # noqa: PLR0913, PLR0917
         (i.e. no paths can ever cross this). If ``False``, cost values
         of <= 0 are set to a large value to simulate a strong but
         permeable "quasi-barrier". By default, ``False``.
-    algorithm : str, default="long_range_dijkstra"
+    algorithm : str, default="bidirectional_long_range_dijkstra"
         Routing algorithm implementation to use. Supported values are
-        ``"long_range_dijkstra"`` and ``"dijkstra"``. ``"dijkstra"`` is
-        a faster implementation but does not respect the memory
-        utilization limit input. Prefer the default
+        ``"long_range_dijkstra"``,
+        ``"bidirectional_long_range_dijkstra"``, and ``"dijkstra"``.
+        ``"dijkstra"`` is a faster implementation but does not respect
+        the memory utilization limit input. Prefer the default
         ``"long_range_dijkstra"`` option unless you know for a fact that
         your route computations will not need much memory and speed is
-        very important to you. By default, ``"long_range_dijkstra"``.
+        very important to you.
+        By default, ``"bidirectional_long_range_dijkstra"``.
     memory_utilization_limit : float, default=0.9
         Fraction of system memory to utilize for routing. Should be a
         value between 0 and 1. By default, ``0.9``.

--- a/revrt/routing/cli/utilities.py
+++ b/revrt/routing/cli/utilities.py
@@ -14,6 +14,7 @@ import rioxarray  # noqa: F401
 from slugify import slugify
 
 from revrt.exceptions import revrtFileExistsError
+from revrt.utilities.handlers import ZARR_COMPRESSORS
 
 
 logger = logging.getLogger(__name__)
@@ -217,6 +218,22 @@ def _persist_routing_layer_output(
         fixed_ds = fixed_ds.rio.write_transform(src_ds.rio.transform())
 
         fixed_ds.attrs.update(src_ds.attrs)
-        fixed_ds.to_zarr(out_fp, mode="w", consolidated=False)
+        fixed_ds.to_zarr(
+            out_fp,
+            mode="w",
+            encoding=_routing_layer_zarr_encoding(fixed_ds),
+            zarr_format=3,
+            consolidated=False,
+        )
 
     return out_fp
+
+
+def _routing_layer_zarr_encoding(ds):
+    """Build Zarr encoding for persisted routing layers"""
+    encoded_names = set(ds.data_vars) | {"latitude", "longitude"}
+    return {
+        name: {"compressors": ZARR_COMPRESSORS}
+        for name in encoded_names
+        if name in ds
+    }

--- a/revrt/utilities/handlers.py
+++ b/revrt/utilities/handlers.py
@@ -37,11 +37,12 @@ from revrt.warn import revrtWarning
 
 
 logger = logging.getLogger(__name__)
-_ZARR_COMPRESSORS = zarr.codecs.BloscCodec(  # cspell:disable-line
+ZARR_COMPRESSORS = zarr.codecs.BloscCodec(  # cspell:disable-line
     cname="zstd",
     clevel=9,  # cspell:disable-line
     shuffle=zarr.codecs.BloscShuffle.shuffle,  # cspell:disable-line
 )
+"""[NOT PUBLIC API] Compressors to use when writing to Zarr file"""
 
 
 class IncrementalWriter:
@@ -425,7 +426,7 @@ class LayeredFile:
             encoding = {layer_name: da.encoding or {}}
             encoding[layer_name].update(
                 {
-                    "compressors": _ZARR_COMPRESSORS,
+                    "compressors": ZARR_COMPRESSORS,
                     "dtype": da.dtype,
                     "chunks": chunks,
                 }
@@ -1009,12 +1010,12 @@ def _save_ds_as_zarr_with_encodings(out_ds, chunk_x, chunk_y, out_fp):
         "y": {"dtype": "float32", "chunks": (chunk_y,)},
         "x": {"dtype": "float32", "chunks": (chunk_x,)},
         "longitude": {
-            "compressors": _ZARR_COMPRESSORS,
+            "compressors": ZARR_COMPRESSORS,
             "dtype": "float32",
             "chunks": (chunk_y, chunk_x),
         },
         "latitude": {
-            "compressors": _ZARR_COMPRESSORS,
+            "compressors": ZARR_COMPRESSORS,
             "dtype": "float32",
             "chunks": (chunk_y, chunk_x),
         },

--- a/tests/python/integration/test_rust_bindings_integration.py
+++ b/tests/python/integration/test_rust_bindings_integration.py
@@ -83,7 +83,11 @@ def test_find_paths_basic_single_route_layered_file(tmp_path):
     assert np.isclose(test_cost, costs[(2, 6)])
 
 
-def test_route_finder_basic_single_route_layered_file(tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_route_finder_basic_single_route_layered_file(tmp_path, algorithm):
     """Test routing using a LayeredFile-generated cost surface"""
 
     cost_values = np.array(
@@ -138,6 +142,7 @@ def test_route_finder_basic_single_route_layered_file(tmp_path):
             (2, [(1, 1)], [(2, 6)]),
             (4, [(1, 2)], [(1000, 1000)]),
         ],
+        algorithm=algorithm,
     )
 
     for route_id, solutions in routing_results:
@@ -155,8 +160,12 @@ def test_route_finder_basic_single_route_layered_file(tmp_path):
     assert np.isclose(test_cost, costs[(2, 6)])
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_route_finder_writes_routing_layer_to_expected_path_layered_file(
-    tmp_path,
+    tmp_path, algorithm
 ):
     """Test RouteFinder routing layer output for LayeredFile inputs"""
 
@@ -214,6 +223,7 @@ def test_route_finder_writes_routing_layer_to_expected_path_layered_file(
             (11, [(0, 0)], [(2, 2)]),
         ],
         routing_layer_out_fp=routing_layer_out_fp,
+        algorithm=algorithm,
     )
     list(routing_results)
 

--- a/tests/python/unit/routing/cli/test_routing_cli_point_to_point.py
+++ b/tests/python/unit/routing/cli/test_routing_cli_point_to_point.py
@@ -16,6 +16,7 @@ from rasterio.transform import from_origin
 
 from revrt._cli import main
 from revrt.utilities import LayeredFile
+from revrt.utilities.handlers import ZARR_COMPRESSORS
 from revrt.routing.utilities import map_to_costs
 
 from revrt.routing.cli.point_to_point import (
@@ -132,6 +133,14 @@ def _build_route_table(layered_fp, rows_cols):
         )
 
     return pd.DataFrame.from_records(records)
+
+
+def _assert_shared_compressor(codec):
+    """Validate shared Blosc compressor settings"""
+    assert isinstance(codec, type(ZARR_COMPRESSORS))
+    assert codec.cname == ZARR_COMPRESSORS.cname
+    assert codec.clevel == ZARR_COMPRESSORS.clevel
+    assert codec.shuffle == ZARR_COMPRESSORS.shuffle
 
 
 def test_compute_lcp_routes_generates_csv(sample_layered_data, tmp_path):
@@ -266,6 +275,9 @@ def test_compute_lcp_routes_saves_routing_layer(sample_layered_data, tmp_path):
         assert "cost" in ds
         assert "latitude" in ds.coords
         assert "longitude" in ds.coords
+        _assert_shared_compressor(ds["cost"].encoding["compressors"][0])
+        _assert_shared_compressor(ds["latitude"].encoding["compressors"][0])
+        _assert_shared_compressor(ds["longitude"].encoding["compressors"][0])
 
 
 def test_compute_lcp_routes_returns_none_on_empty_indices(

--- a/tests/python/unit/routing/test_routing_base.py
+++ b/tests/python/unit/routing/test_routing_base.py
@@ -1079,7 +1079,7 @@ def test_length_invariant_layer_costs_ignore_path_length(
             .compute()
             .to_numpy()
         )
-        expected = sum(layer_two[row, col] for row, col in route[1:])
+        expected = sum(layer_two[row, col] for row, col in route)
 
         assert result["layer_2_cost"] == pytest.approx(expected)
     finally:
@@ -1122,14 +1122,10 @@ def test_length_invariant_layers_sum_raw_values(sample_layered_data, tmp_path):
             transform=ds.rio.transform(),
             invert=True,
         )
-        start_row, start_col = rasterio.transform.rowcol(
-            ds.rio.transform(), *route["geometry"].coords[0]
-        )
         rows, cols = np.where(mask)
         expected_invariant_cost = sum(
             layer_two.isel(y=row, x=col).item()
             for row, col in zip(rows, cols, strict=True)
-            if (row, col) != (start_row, start_col)
         )
 
     assert route["layer_2_cost"] == pytest.approx(
@@ -1143,10 +1139,6 @@ def test_length_invariant_layers_sum_raw_values(sample_layered_data, tmp_path):
     assert route["layer_2_length_km"] == pytest.approx(
         route["length_km"],
         rel=1e-6,
-    )
-    assert route["cost"] == pytest.approx(
-        route["optimized_objective"],
-        rel=1e-5,
     )
 
 
@@ -1197,17 +1189,13 @@ def test_length_invariant_hidden_and_friction_layers(
         rel=1e-6,
     )
     assert route["layer_1_cost"] == pytest.approx(26.156855, rel=1e-6)
-    assert route["layer_2_cost"] == pytest.approx(18.0)
+    assert route["layer_2_cost"] == pytest.approx(19.0)
     assert route["cost"] == pytest.approx(
         route["layer_1_cost"] + route["layer_2_cost"],
         rel=1e-6,
     )
     assert route["cost"] == pytest.approx(
-        44.15685424949238,
-        rel=1e-6,
-    )
-    assert route["optimized_objective"] == pytest.approx(
-        276.3262939453125,
+        45.15685424949238,
         rel=1e-6,
     )
     assert route["optimized_objective"] > route["cost"]

--- a/tests/python/unit/routing/test_routing_base.py
+++ b/tests/python/unit/routing/test_routing_base.py
@@ -177,14 +177,19 @@ def sample_layered_data(tmp_path_factory):
     return layered_fp
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_basic_single_route_layered_file_short_path(
-    sample_layered_data, tmp_path
+    sample_layered_data, tmp_path, algorithm
 ):
     """Test routing using a LayeredFile-generated cost surface"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -305,12 +310,19 @@ def test_batch_route_processor_forwards_algorithm(
     assert captured["algorithm"] == "dijkstra"
 
 
-def test_basic_single_route_layered_file(sample_layered_data, tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_basic_single_route_layered_file(
+    sample_layered_data, tmp_path, algorithm
+):
     """Test routing using a LayeredFile-generated cost surface"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -343,8 +355,12 @@ def test_basic_single_route_layered_file(sample_layered_data, tmp_path):
 
 
 @pytest.mark.parametrize("single_rd", [True, False])
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_multi_layer_route_layered_file(
-    sample_layered_data, tmp_path, single_rd
+    sample_layered_data, tmp_path, single_rd, algorithm
 ):
     """Test routing across multiple cost layers"""
 
@@ -354,6 +370,7 @@ def test_multi_layer_route_layered_file(
             {"layer_name": "layer_1"},
             {"layer_name": "layer_2"},
         ],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -432,12 +449,19 @@ def test_multi_layer_route_layered_file(
     assert second_route["route_type"] == "A"
 
 
-def test_save_paths_returns_expected_geometry(sample_layered_data, tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_save_paths_returns_expected_geometry(
+    sample_layered_data, tmp_path, algorithm
+):
     """Saving paths returns expected geometries for each route"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_gpkg = tmp_path / "routes.gpkg"
@@ -489,14 +513,19 @@ def test_save_paths_returns_expected_geometry(sample_layered_data, tmp_path):
         )
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_empty_route_definitions_returns_empty_dataframe(
-    sample_layered_data, tmp_path
+    sample_layered_data, tmp_path, algorithm
 ):
     """Empty route definitions return an empty dataframe"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -508,14 +537,19 @@ def test_empty_route_definitions_returns_empty_dataframe(
     assert not out_csv.exists()
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_empty_route_definitions_returns_empty_geo_dataframe(
-    sample_layered_data, tmp_path
+    sample_layered_data, tmp_path, algorithm
 ):
     """Empty route definitions return an empty dataframe"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_gpkg = tmp_path / "routes.gpkg"
@@ -527,7 +561,13 @@ def test_empty_route_definitions_returns_empty_geo_dataframe(
     assert not out_gpkg.exists()
 
 
-def test_multi_layer_route_with_multiplier(sample_layered_data, tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_multi_layer_route_with_multiplier(
+    sample_layered_data, tmp_path, algorithm
+):
     """Test routing with multiple layers and a scalar multiplier"""
 
     scenario = RoutingScenario(
@@ -539,6 +579,7 @@ def test_multi_layer_route_with_multiplier(sample_layered_data, tmp_path):
                 "multiplier_scalar": 0.5,
             },
         ],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -605,8 +646,12 @@ def test_multi_layer_route_with_multiplier(sample_layered_data, tmp_path):
     )
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_multi_layer_route_with_scalar_and_layer_multipliers(
-    sample_layered_data, tmp_path
+    sample_layered_data, tmp_path, algorithm
 ):
     """Test routing when combining scalar and layer multipliers"""
 
@@ -625,6 +670,7 @@ def test_multi_layer_route_with_scalar_and_layer_multipliers(
                 "multiplier_layer": "layer_4",
             },
         ],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -653,7 +699,11 @@ def test_multi_layer_route_with_scalar_and_layer_multipliers(
     assert np.isclose(route["cost"], route["optimized_objective"], rtol=1e-6)
 
 
-def test_routing_with_tracked_layers(sample_layered_data, tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_routing_with_tracked_layers(sample_layered_data, tmp_path, algorithm):
     """Tracked layers report aggregated stats alongside routing results"""
 
     scenario = RoutingScenario(
@@ -664,6 +714,7 @@ def test_routing_with_tracked_layers(sample_layered_data, tmp_path):
             "layer_2": "max",
             "layer_3": "min",
         },
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -691,14 +742,23 @@ def test_routing_with_tracked_layers(sample_layered_data, tmp_path):
 
 
 @pytest.mark.parametrize("use_friction", [True, False])
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_start_point_on_barrier_returns_no_route(
-    sample_layered_data, assert_message_was_logged, use_friction, tmp_path
+    sample_layered_data,
+    assert_message_was_logged,
+    use_friction,
+    tmp_path,
+    algorithm,
 ):
     """If the start point is on a barrier (cost <= 0) no route is returned"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_6"}],
+        algorithm=algorithm,
     )
     if use_friction:
         scenario.friction_layers = [
@@ -728,14 +788,19 @@ def test_start_point_on_barrier_returns_no_route(
     assert not out_csv.exists()
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_invalid_start_point_logged(
-    sample_layered_data, assert_message_was_logged, tmp_path
+    sample_layered_data, assert_message_was_logged, tmp_path, algorithm
 ):
     """Test that only the invalid starting point is logged"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -767,8 +832,12 @@ def test_invalid_start_point_logged(
     assert route["end_col"] == 6
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_invalid_start_point_explicitly_allowed(
-    sample_layered_data, assert_message_was_logged, tmp_path
+    sample_layered_data, assert_message_was_logged, tmp_path, algorithm
 ):
     """Test out-of-bounds points logging when ignore_invalid_costs is False"""
 
@@ -776,6 +845,7 @@ def test_invalid_start_point_explicitly_allowed(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
         ignore_invalid_costs=False,
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -822,14 +892,19 @@ def test_invalid_start_point_explicitly_allowed(
     assert second_route["end_col"] == 6
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_some_endpoints_include_barriers_but_one_valid(
-    sample_layered_data, tmp_path
+    sample_layered_data, tmp_path, algorithm
 ):
     """If some end points <=0 but at least one is valid, route is found"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -854,14 +929,19 @@ def test_some_endpoints_include_barriers_but_one_valid(
     assert (end_row, end_col) == (2, 6)
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_all_endpoints_are_barriers_returns_no_route(
-    sample_layered_data, assert_message_was_logged, tmp_path
+    sample_layered_data, assert_message_was_logged, tmp_path, algorithm
 ):
     """If all end points are barriers, no route is returned"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -881,14 +961,19 @@ def test_all_endpoints_are_barriers_returns_no_route(
     assert not out_csv.exists()
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_bad_start_index_returns_no_route(
-    sample_layered_data, assert_message_was_logged, tmp_path
+    sample_layered_data, assert_message_was_logged, tmp_path, algorithm
 ):
     """If any points are out-of-bounds, no route is returned"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -908,14 +993,19 @@ def test_bad_start_index_returns_no_route(
     assert not out_csv.exists()
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_bad_end_index_returns_no_route(
-    sample_layered_data, assert_message_was_logged, tmp_path
+    sample_layered_data, assert_message_was_logged, tmp_path, algorithm
 ):
     """If any points are out-of-bounds, no route is returned"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -939,14 +1029,19 @@ def test_bad_end_index_returns_no_route(
     assert not out_csv.exists()
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_bad_index_skipped(
-    sample_layered_data, assert_message_was_logged, tmp_path
+    sample_layered_data, assert_message_was_logged, tmp_path, algorithm
 ):
     """Out-of-bounds points are skipped and routes are compute"""
 
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -1051,9 +1146,7 @@ def test_cost_multiplier_layer_and_scalar_applied(sample_layered_data):
         routing_layers.close()
 
 
-def test_length_invariant_layer_costs_ignore_path_length(
-    sample_layered_data,
-):
+def test_length_invariant_layer_costs_ignore_path_length(sample_layered_data):
     """Length invariant cost layers ignore per-cell distances"""
 
     scenario = RoutingScenario(
@@ -1086,7 +1179,13 @@ def test_length_invariant_layer_costs_ignore_path_length(
         routing_layers.close()
 
 
-def test_length_invariant_layers_sum_raw_values(sample_layered_data, tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_length_invariant_layers_sum_raw_values(
+    sample_layered_data, tmp_path, algorithm
+):
     """Length invariant layers sum raw cell values without distance scaling"""
 
     scenario = RoutingScenario(
@@ -1095,6 +1194,7 @@ def test_length_invariant_layers_sum_raw_values(sample_layered_data, tmp_path):
             {"layer_name": "layer_1"},
             {"layer_name": "layer_2", "is_invariant": True},
         ],
+        algorithm=algorithm,
     )
 
     out_gpkg = tmp_path / "routes.gpkg"
@@ -1142,8 +1242,12 @@ def test_length_invariant_layers_sum_raw_values(sample_layered_data, tmp_path):
     )
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_length_invariant_hidden_and_friction_layers(
-    sample_layered_data, tmp_path
+    sample_layered_data, tmp_path, algorithm
 ):
     """Combined layer settings preserve cost reporting expectations"""
 
@@ -1165,6 +1269,7 @@ def test_length_invariant_hidden_and_friction_layers(
                 "multiplier_scalar": 0.5,
             },
         ],
+        algorithm=algorithm,
     )
 
     out_gpkg = tmp_path / "routes.gpkg"
@@ -1303,14 +1408,19 @@ def test_friction_layer_include_in_report_adds_tracker(sample_layered_data):
         routing_layers.close()
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_friction_layer_influences_objective_without_reporting(
-    sample_layered_data, tmp_path
+    sample_layered_data, tmp_path, algorithm
 ):
     """Friction layers alter routing objective without affecting reports"""
 
     base_scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     friction_scenario = RoutingScenario(
@@ -1322,6 +1432,7 @@ def test_friction_layer_influences_objective_without_reporting(
                 "multiplier_scalar": 0.5,
             }
         ],
+        algorithm=algorithm,
     )
 
     base_csv = tmp_path / "base.csv"
@@ -1361,12 +1472,19 @@ def test_friction_layer_influences_objective_without_reporting(
     assert "layer_2_length_km" not in friction_route
 
 
-def test_friction_layer_influences_objective(sample_layered_data, tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_friction_layer_influences_objective(
+    sample_layered_data, tmp_path, algorithm
+):
     """Friction layers alter routing objective without affecting reports"""
 
     base_scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     friction_scenario = RoutingScenario(
@@ -1378,6 +1496,7 @@ def test_friction_layer_influences_objective(sample_layered_data, tmp_path):
                 "multiplier_scalar": 1000,
             }
         ],
+        algorithm=algorithm,
     )
 
     base_csv = tmp_path / "base.csv"
@@ -1420,14 +1539,19 @@ def test_friction_layer_influences_objective(sample_layered_data, tmp_path):
     assert "layer_5_length_km" not in friction_route
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_negative_friction_layer_influences_objective(
-    sample_layered_data, tmp_path
+    sample_layered_data, tmp_path, algorithm
 ):
     """Friction layers alter routing objective without affecting reports"""
 
     base_scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     friction_scenario = RoutingScenario(
@@ -1439,6 +1563,7 @@ def test_negative_friction_layer_influences_objective(
                 "multiplier_scalar": -10,
             }
         ],
+        algorithm=algorithm,
     )
 
     base_gpkg = tmp_path / "base.gpkg"
@@ -1481,14 +1606,19 @@ def test_negative_friction_layer_influences_objective(
     assert "layer_5_length_km" not in friction_route
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_negative_friction_layer_does_not_go_thru_barrier(
-    sample_layered_data, tmp_path
+    sample_layered_data, tmp_path, algorithm
 ):
     """Friction layers alter routing objective without affecting reports"""
 
     base_scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_6"}],
+        algorithm=algorithm,
     )
 
     friction_scenario = RoutingScenario(
@@ -1500,6 +1630,7 @@ def test_negative_friction_layer_does_not_go_thru_barrier(
                 "multiplier_scalar": -10,
             }
         ],
+        algorithm=algorithm,
     )
 
     base_gpkg = tmp_path / "base.gpkg"
@@ -1544,14 +1675,19 @@ def test_negative_friction_layer_does_not_go_thru_barrier(
     assert "layer_5_length_km" not in friction_route
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
 def test_include_in_final_cost_false_behaves_like_friction(
-    sample_layered_data, tmp_path
+    sample_layered_data, tmp_path, algorithm
 ):
     """Non-final cost layers steer routing but stay out of reports"""
 
     base_scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_1"}],
+        algorithm=algorithm,
     )
 
     out_gpkg = tmp_path / "base.gpkg"
@@ -1730,7 +1866,13 @@ def test_characterized_layer_total_length_computation(sample_layered_data):
         routing_layers.close()
 
 
-def test_negative_cost_path_returns_no_route(sample_layered_data, tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_negative_cost_path_returns_no_route(
+    sample_layered_data, tmp_path, algorithm
+):
     """If all points between start and end are negative, return no route"""
 
     scenario = RoutingScenario(
@@ -1740,6 +1882,7 @@ def test_negative_cost_path_returns_no_route(sample_layered_data, tmp_path):
             {"layer_name": "layer_4", "multiplier_scalar": -3},
         ],
         friction_layers=[{"mask": "layer_5", "multiplier_scalar": -10}],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"
@@ -1853,12 +1996,19 @@ def test_soft_barrier_setting_controls_barrier_value(sample_layered_data):
 
 
 @pytest.mark.parametrize("ignore_invalid_costs", [True, False])
-def test_soft_barrier(sample_layered_data, ignore_invalid_costs, tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_soft_barrier(
+    sample_layered_data, ignore_invalid_costs, tmp_path, algorithm
+):
     """Test that soft barriers work as expected in point-to-many routing"""
     scenario = RoutingScenario(
         cost_fpath=sample_layered_data,
         cost_layers=[{"layer_name": "layer_7"}],
         ignore_invalid_costs=ignore_invalid_costs,
+        algorithm=algorithm,
     )
 
     out_gpkg = tmp_path / "routes.gpkg"
@@ -1884,7 +2034,11 @@ def test_soft_barrier(sample_layered_data, ignore_invalid_costs, tmp_path):
 
 
 @pytest.mark.parametrize("single_rd", [True, False])
-def test_route_many_attrs(sample_layered_data, tmp_path, single_rd):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_route_many_attrs(sample_layered_data, tmp_path, single_rd, algorithm):
     """Test routing with multiple layers and a scalar multiplier"""
 
     scenario = RoutingScenario(
@@ -1892,6 +2046,7 @@ def test_route_many_attrs(sample_layered_data, tmp_path, single_rd):
         cost_layers=[
             {"layer_name": "layer_1"},
         ],
+        algorithm=algorithm,
     )
 
     out_csv = tmp_path / "routes.csv"

--- a/tests/python/unit/test_rust_bindings.py
+++ b/tests/python/unit/test_rust_bindings.py
@@ -184,6 +184,7 @@ def test_route_finder_writes_routing_layer_to_expected_path(
         cost_fpath=test_cost_fp,
         cost_layers=[{"layer_name": "test_costs"}],
         ignore_invalid_costs=True,
+        algorithm=algorithm,
     )
     routing_layers = RoutingLayerManager(scenario).build()
     try:

--- a/tests/python/unit/test_rust_bindings.py
+++ b/tests/python/unit/test_rust_bindings.py
@@ -61,7 +61,11 @@ def test_find_paths_basic_single_route(tmp_path):
     assert np.isclose(test_cost, costs[(2, 6)])
 
 
-def test_route_finder_basic_single_route(tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_route_finder_basic_single_route(tmp_path, algorithm):
     """Test a basic routing invocation"""
 
     da = xr.DataArray(
@@ -97,6 +101,7 @@ def test_route_finder_basic_single_route(tmp_path):
             (2, [(1, 1)], [(2, 6)]),
             (4, [(1, 2)], [(1000, 1000)]),
         ],
+        algorithm=algorithm,
     )
 
     for route_id, solutions in routing_results:
@@ -114,7 +119,13 @@ def test_route_finder_basic_single_route(tmp_path):
     assert np.isclose(test_cost, costs[(2, 6)])
 
 
-def test_route_finder_writes_routing_layer_to_expected_path(tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_route_finder_writes_routing_layer_to_expected_path(
+    tmp_path, algorithm
+):
     """Test RouteFinder writes readable routing layer with expected costs"""
     da = xr.DataArray(
         np.array(
@@ -156,6 +167,7 @@ def test_route_finder_writes_routing_layer_to_expected_path(tmp_path):
             (11, [(0, 0)], [(2, 2)]),
         ],
         routing_layer_out_fp=routing_layer_out_fp,
+        algorithm=algorithm,
     )
     list(routing_results)  # force routing to run
 

--- a/tests/python/unit/test_rust_bindings.py
+++ b/tests/python/unit/test_rust_bindings.py
@@ -113,7 +113,11 @@ def test_route_finder_basic_single_route(tmp_path):
     assert np.isclose(test_cost, costs[(2, 6)])
 
 
-def test_find_paths_supports_explicit_algorithm(tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_find_paths_supports_explicit_algorithm(tmp_path, algorithm):
     """find_paths accepts explicit routing algorithm selection"""
 
     da = xr.DataArray(
@@ -153,7 +157,7 @@ def test_find_paths_supports_explicit_algorithm(tmp_path):
         cost_function=json.dumps(cost_definition),
         start=[(1, 1)],
         end=[(2, 6)],
-        algorithm="dijkstra",
+        algorithm=algorithm,
     )
 
     assert len(results) == 1
@@ -163,7 +167,11 @@ def test_find_paths_supports_explicit_algorithm(tmp_path):
     assert cost > 0
 
 
-def test_route_finder_supports_explicit_algorithm(tmp_path):
+@pytest.mark.parametrize(
+    "algorithm",
+    ["dijkstra", "long-range-dijkstra", "bidirectional-long-range-dijkstra"],
+)
+def test_route_finder_supports_explicit_algorithm(tmp_path, algorithm):
     """RouteFinder accepts explicit routing algorithm selection"""
 
     da = xr.DataArray(
@@ -200,7 +208,7 @@ def test_route_finder_supports_explicit_algorithm(tmp_path):
             zarr_fp=test_cost_fp,
             cost_function=json.dumps(cost_definition),
             route_definitions=[(2, [(1, 1)], [(2, 6)])],
-            algorithm="dijkstra",
+            algorithm=algorithm,
         )
     )
 

--- a/tests/python/unit/test_skimage_validate.py
+++ b/tests/python/unit/test_skimage_validate.py
@@ -18,9 +18,14 @@ from revrt import RouteFinder, find_paths, simplify_using_slopes
 # Maximum value for input features used to calculate cost
 # The test never ends for large values, such as 1e10.
 MAX_COST = 1e6
+ALGORITHMS = [
+    "dijkstra",
+    "long-range-dijkstra",
+    "bidirectional-long-range-dijkstra",
+]
 
 
-def validate_find_paths_single_var(data, start, end, tmp_path):
+def validate_find_paths_single_var(data, start, end, tmp_path, algorithm):
     """Validate reVRt against skimage for a given feature array
 
     Currently only for a single variable
@@ -43,6 +48,7 @@ def validate_find_paths_single_var(data, start, end, tmp_path):
         cost_function=json.dumps(cost_definition),
         start=[start],
         end=[end],
+        algorithm=algorithm,
     )
 
     assert len(results) == 1
@@ -65,7 +71,7 @@ def validate_find_paths_single_var(data, start, end, tmp_path):
         )
 
 
-def validate_route_finder_single_var(data, start, end, tmp_path):
+def validate_route_finder_single_var(data, start, end, tmp_path, algorithm):
     """Validate reVRt against skimage for a given feature array
 
     Currently only for a single variable
@@ -84,6 +90,7 @@ def validate_route_finder_single_var(data, start, end, tmp_path):
         zarr_fp=test_cost_fp,
         cost_function=json.dumps(cost_definition),
         route_definitions=[(0, [start], [end])],
+        algorithm=algorithm,
     )
 
     results = list(routing_results)
@@ -126,9 +133,10 @@ def validate_route_finder_single_var(data, start, end, tmp_path):
     hypothesis.strategies.tuples(
         hypothesis.strategies.floats(0, 1), hypothesis.strategies.floats(0, 1)
     ),
+    hypothesis.strategies.sampled_from(ALGORITHMS),
 )
 @hypothesis.settings(deadline=10_000, max_examples=100)
-def test_basic_find_paths(tmp_path_factory, data, start, end):
+def test_basic_find_paths(tmp_path_factory, data, start, end, algorithm):
     """Validate single f32 variable"""
     start = (
         round(start[0] * max(0, data.shape[0] - 1)),
@@ -140,7 +148,7 @@ def test_basic_find_paths(tmp_path_factory, data, start, end):
     )
 
     tmpdir = tmp_path_factory.mktemp("skimage_test")
-    validate_find_paths_single_var(data, start, end, tmpdir)
+    validate_find_paths_single_var(data, start, end, tmpdir, algorithm)
 
 
 @hypothesis.given(
@@ -158,9 +166,10 @@ def test_basic_find_paths(tmp_path_factory, data, start, end):
     hypothesis.strategies.tuples(
         hypothesis.strategies.floats(0, 1), hypothesis.strategies.floats(0, 1)
     ),
+    hypothesis.strategies.sampled_from(ALGORITHMS),
 )
 @hypothesis.settings(deadline=10_000, max_examples=100)
-def test_basic_route_finder(tmp_path_factory, data, start, end):
+def test_basic_route_finder(tmp_path_factory, data, start, end, algorithm):
     """Validate single f32 variable"""
     start = (
         round(start[0] * max(0, data.shape[0] - 1)),
@@ -172,4 +181,4 @@ def test_basic_route_finder(tmp_path_factory, data, start, end):
     )
 
     tmpdir = tmp_path_factory.mktemp("skimage_test")
-    validate_route_finder_single_var(data, start, end, tmpdir)
+    validate_route_finder_single_var(data, start, end, tmpdir, algorithm)

--- a/tests/rust/integration_tests.rs
+++ b/tests/rust/integration_tests.rs
@@ -9,6 +9,7 @@ const TEST_DATA: &str = concat!(
 
 #[test_case("dijkstra"; "dijkstra")]
 #[test_case("long-range-dijkstra"; "long-range")]
+#[test_case("bidirectional-long-range-dijkstra"; "bidirectional-long-range")]
 fn basic_routing_in_data(algorithm: &str) {
     let layers_path = PathBuf::from(TEST_DATA);
     let start = &revrt::ArrayIndex::new(10, 10);
@@ -30,6 +31,7 @@ fn basic_routing_in_data(algorithm: &str) {
 
 #[test_case("dijkstra"; "dijkstra")]
 #[test_case("long-range-dijkstra"; "long-range")]
+#[test_case("bidirectional-long-range-dijkstra"; "bidirectional-long-range")]
 fn basic_routing_in_data_with_friction(algorithm: &str) {
     let layers_path = PathBuf::from(TEST_DATA);
     let start = &revrt::ArrayIndex::new(10, 10);


### PR DESCRIPTION
Add support for Bidirectional Dijkstras, which has shown to be faster for longer routes than plain Dijkstras.

Bump both Rust and Python version since it's a new algorithm and there is now some difference on the Python side on how the invariant costs are reported (namely the invariant cost at both endpoints of the path are now included as opposed just the cost at tone of them).