### PR TITLE
Allow diagonal traversal when switching routing options

### DIFF
--- a/crates/revrt/src/dataset/mod.rs
+++ b/crates/revrt/src/dataset/mod.rs
@@ -37,6 +37,60 @@ pub(crate) use lazy_subset::LazySubset;
 use reader::DerivedDataReader;
 use swap::{initialize_swap, inspect_source_layout};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum NeighborhoodGeometry {
+    Side,
+    Corner,
+}
+
+impl NeighborhoodGeometry {
+    pub(super) fn edge_scale(self) -> f32 {
+        match self {
+            Self::Side => 0.5,
+            Self::Corner => f32::sqrt(2.0) / 2.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct NeighborhoodPoint {
+    pub(super) destination: ArrayIndex,
+    pub(super) geometry: NeighborhoodGeometry,
+    pub(super) destination_primary_cost: f32,
+    pub(super) destination_invariant_cost: f32,
+    pub(super) destination_is_hard_barrier: bool,
+}
+
+impl NeighborhoodPoint {
+    pub(super) fn edge_scale(&self) -> f32 {
+        self.geometry.edge_scale()
+    }
+
+    pub(super) fn traversal_cost(
+        &self,
+        source_primary_cost: f32,
+        source_multiplier: f32,
+        destination_multiplier: f32,
+    ) -> Option<f32> {
+        if self.destination_is_hard_barrier || self.destination_primary_cost.is_nan() {
+            return None;
+        }
+
+        Some(
+            self.edge_scale()
+                * (source_primary_cost * source_multiplier
+                    + self.destination_primary_cost * destination_multiplier)
+                + self.destination_invariant_cost * destination_multiplier,
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct RoutingOptionNeighborhood {
+    pub(super) center_primary_cost: Option<f32>,
+    pub(super) points: Vec<NeighborhoodPoint>,
+}
+
 /// Manage source features together with derived swap-backed routing data.
 ///
 /// A `Dataset` owns access to the original feature store, the temporary swap
@@ -162,7 +216,7 @@ impl Dataset {
         })
     }
 
-    /// Return reachable movement costs in the 3x3 neighborhood of an index.
+    /// Return 3x3 routing neighborhoods for all option states at an index.
     ///
     /// Derived data is materialized on demand for the needed swap chunks
     /// before the neighborhood is read.
@@ -171,11 +225,15 @@ impl Dataset {
     /// `index`: Center cell whose 3x3 neighborhood should be queried.
     ///
     /// # Returns
-    /// A vector of neighboring indices paired with movement costs from the
-    /// center cell.
-    pub(super) fn get_3x3(&self, index: &ArrayIndex) -> Vec<(ArrayIndex, f32)> {
+    /// A vector containing one `RoutingOptionNeighborhood` per routing option,
+    /// each with the center primary cost and the reachable neighboring
+    /// cells for that option.
+    pub(super) fn get_3x3_neighborhood_all_options(
+        &self,
+        index: &ArrayIndex,
+    ) -> Vec<RoutingOptionNeighborhood> {
         self.derived_data_reader
-            .get_3x3(index, &self.derived_data_writer)
+            .get_3x3_neighborhood_all_options(index, &self.derived_data_writer)
     }
 
     /// Return soft-barrier cells in the 3x3 neighborhood of an index.
@@ -323,13 +381,14 @@ mod tests {
         let test_points = [ArrayIndex::new_ij(3, 1), ArrayIndex::new_ij(2, 2)];
         let array = zarrs::array::Array::open(dataset.source.clone(), "/A").unwrap();
         for point in test_points {
-            let results = dataset.get_3x3(&point);
+            let neighborhoods = dataset.get_3x3_neighborhood_all_options(&point);
 
             // index 0, 0 has a cost of 0 and should therefore be filtered out
             assert!(
-                !results
+                !neighborhoods[point.option as usize]
+                    .points
                     .iter()
-                    .any(|(ArrayIndex { i, j, .. }, _)| *i == 0 && *j == 0)
+                    .any(|point| point.destination.i == 0 && point.destination.j == 0)
             );
             let ArrayIndex { i: ci, j: cj, .. } = point;
             let center_subset = zarrs::array_subset::ArraySubset::new_with_ranges(&[
@@ -340,6 +399,7 @@ mod tests {
             let center_cost: f32 = array
                 .retrieve_array_subset_elements(&center_subset)
                 .expect("Error reading zarr data")[0];
+            let results = same_option_neighbors(&neighborhoods, point.option, Some(center_cost));
 
             for (ArrayIndex { i, j, .. }, val) in results {
                 let subset = zarrs::array_subset::ArraySubset::new_with_ranges(&[
@@ -419,9 +479,11 @@ mod tests {
         let test_points = [ArrayIndex::new_ij(3, 1), ArrayIndex::new_ij(2, 2)];
         let array = zarrs::array::Array::open(dataset.source.clone(), "/A").unwrap();
         for point in test_points {
-            let results = dataset.get_3x3(&point);
+            let neighborhoods = dataset.get_3x3_neighborhood_all_options(&point);
+            let results = &neighborhoods[point.option as usize].points;
 
-            for (ArrayIndex { i, j, .. }, val) in results {
+            for neighborhood_point in results {
+                let ArrayIndex { i, j, .. } = neighborhood_point.destination;
                 let subset = zarrs::array_subset::ArraySubset::new_with_ranges(&[
                     0..1,
                     i..(i + 1),
@@ -431,7 +493,10 @@ mod tests {
                     .retrieve_array_subset_elements(&subset)
                     .expect("Error reading zarr data");
                 assert_eq!(subset_elements.len(), 1);
-                assert_eq!(subset_elements[0], val)
+                assert_eq!(
+                    subset_elements[0],
+                    neighborhood_point.destination_invariant_cost
+                )
             }
         }
     }
@@ -448,13 +513,14 @@ mod tests {
         let array_b = zarrs::array::Array::open(dataset.source.clone(), "/B").unwrap();
         let array_c = zarrs::array::Array::open(dataset.source.clone(), "/C").unwrap();
         for point in test_points {
-            let results = dataset.get_3x3(&point);
+            let neighborhoods = dataset.get_3x3_neighborhood_all_options(&point);
 
             // index 0, 0 has a cost of 0 and should therefore be filtered out
             assert!(
-                !results
+                !neighborhoods[point.option as usize]
+                    .points
                     .iter()
-                    .any(|(ArrayIndex { i, j, .. }, _)| *i == 0 && *j == 0)
+                    .any(|point| point.destination.i == 0 && point.destination.j == 0)
             );
             let ArrayIndex { i: ci, j: cj, .. } = point;
             let center_subset = zarrs::array_subset::ArraySubset::new_with_ranges(&[
@@ -474,6 +540,7 @@ mod tests {
 
             let center_cost: f32 =
                 center_a + center_b * 100. + center_a * center_b + center_c * center_a * 2.;
+            let results = same_option_neighbors(&neighborhoods, point.option, Some(center_cost));
 
             for (ArrayIndex { i, j, .. }, val) in results {
                 let subset = zarrs::array_subset::ArraySubset::new_with_ranges(&[
@@ -530,7 +597,13 @@ mod tests {
         let dataset =
             Dataset::open(tmp.path(), cost_function, 1_000).expect("Error opening dataset");
 
-        let results = dataset.get_3x3(&ArrayIndex::new_ij(0, 0));
+        let index = ArrayIndex::new_ij(0, 0);
+        let neighborhoods = dataset.get_3x3_neighborhood_all_options(&index);
+        let results = same_option_neighbors(
+            &neighborhoods,
+            index.option,
+            dataset.get_source_cell_value("cost", &index),
+        );
 
         // index 0, 0 has a cost of 0 and should therefore be filtered out
         assert!(
@@ -555,7 +628,13 @@ mod tests {
         let dataset =
             Dataset::open(tmp.path(), cost_function, 1_000).expect("Error opening dataset");
 
-        let results = dataset.get_3x3(&ArrayIndex::new_ij(si, sj));
+        let index = ArrayIndex::new_ij(si, sj);
+        let neighborhoods = dataset.get_3x3_neighborhood_all_options(&index);
+        let results = same_option_neighbors(
+            &neighborhoods,
+            index.option,
+            dataset.get_source_cell_value("cost", &index),
+        );
 
         // index 0, 0 has a cost of 0 and should therefore be filtered out
         assert!(
@@ -594,7 +673,13 @@ mod tests {
         let dataset =
             Dataset::open(tmp.path(), cost_function, 1_000).expect("Error opening dataset");
 
-        let results = dataset.get_3x3(&ArrayIndex::new_ij(si, sj));
+        let index = ArrayIndex::new_ij(si, sj);
+        let neighborhoods = dataset.get_3x3_neighborhood_all_options(&index);
+        let results = same_option_neighbors(
+            &neighborhoods,
+            index.option,
+            dataset.get_source_cell_value("cost", &index),
+        );
 
         // index 0, 0 has a cost of 0 and should therefore be filtered out
         assert!(
@@ -636,7 +721,13 @@ mod tests {
         let dataset =
             Dataset::open(tmp.path(), cost_function, 1_000).expect("Error opening dataset");
 
-        let results = dataset.get_3x3(&ArrayIndex::new_ij(si, sj));
+        let index = ArrayIndex::new_ij(si, sj);
+        let neighborhoods = dataset.get_3x3_neighborhood_all_options(&index);
+        let results = same_option_neighbors(
+            &neighborhoods,
+            index.option,
+            dataset.get_source_cell_value("cost", &index),
+        );
 
         // index 0, 0 has a cost of 0 and should therefore be filtered out
         assert!(
@@ -687,7 +778,12 @@ mod tests {
 
         // Request center neighbors
         let point = ArrayIndex::new_ij(1, 1);
-        let results = dataset.get_3x3(&point);
+        let neighborhoods = dataset.get_3x3_neighborhood_all_options(&point);
+        let results = same_option_neighbors(
+            &neighborhoods,
+            point.option,
+            dataset.get_source_cell_value("A", &point),
+        );
 
         // Build expected results: for each neighbor (excluding center),
         // averaged = 0.5 * (A_neighbor + A_center)
@@ -766,7 +862,9 @@ mod tests {
         let dataset =
             Dataset::open(tmp.path(), cost_function, 1_000).expect("Error opening dataset");
 
-        let results = dataset.get_3x3(&ArrayIndex::new_ij(1, 1));
+        let index = ArrayIndex::new_ij(1, 1);
+        let neighborhoods = dataset.get_3x3_neighborhood_all_options(&index);
+        let results = same_option_neighbors(&neighborhoods, index.option, None);
         assert!(
             results.is_empty(),
             "Found data with `ignore_invalid_costs=true`"
@@ -788,7 +886,9 @@ mod tests {
         let dataset =
             Dataset::open(tmp.path(), cost_function, 1_000).expect("Error opening dataset");
 
-        let results = dataset.get_3x3(&ArrayIndex::new_ij(1, 1));
+        let index = ArrayIndex::new_ij(1, 1);
+        let neighborhoods = dataset.get_3x3_neighborhood_all_options(&index);
+        let results = same_option_neighbors(&neighborhoods, index.option, None);
         assert_eq!(results.len(), 8);
 
         let mut expected: Vec<(ArrayIndex, f32)> = vec![];
@@ -857,7 +957,13 @@ mod tests {
         let dataset =
             Dataset::open(tmp.path(), cost_function, 1_000).expect("Error opening dataset");
 
-        let results = dataset.get_3x3(&ArrayIndex::new_ij(1, 1));
+        let index = ArrayIndex::new_ij(1, 1);
+        let neighborhoods = dataset.get_3x3_neighborhood_all_options(&index);
+        let results = same_option_neighbors(
+            &neighborhoods,
+            index.option,
+            dataset.get_source_cell_value("A", &index),
+        );
         assert_eq!(
             results,
             vec![
@@ -904,7 +1010,13 @@ mod tests {
         let dataset =
             Dataset::open(tmp.path(), cost_function, 1_000).expect("Error opening dataset");
 
-        let results = dataset.get_3x3(&ArrayIndex::new_ij(1, 1));
+        let index = ArrayIndex::new_ij(1, 1);
+        let neighborhoods = dataset.get_3x3_neighborhood_all_options(&index);
+        let results = same_option_neighbors(
+            &neighborhoods,
+            index.option,
+            dataset.get_source_cell_value("A", &index),
+        );
         assert_eq!(results.len(), 8);
     }
 
@@ -952,7 +1064,7 @@ mod tests {
             .expect("Error opening dataset");
 
         let center = ArrayIndex::new_ij(1, 1);
-        dataset.get_3x3(&center);
+        dataset.get_3x3_neighborhood_all_options(&center);
 
         assert_eq!(
             dataset.get_3x3_soft_barrier_cells(&center, 0),
@@ -1010,12 +1122,36 @@ mod tests {
             .expect("Error opening dataset");
 
         let center = ArrayIndex::new_ij(1, 1);
-        dataset.get_3x3(&center);
+        dataset.get_3x3_neighborhood_all_options(&center);
 
         assert_eq!(
             dataset.get_3x3_soft_barrier_cells(&center, 0),
             vec![ArrayIndex::new_ij(0, 1), ArrayIndex::new_ij(1, 0)]
         );
         assert!(dataset.get_3x3_soft_barrier_cells(&center, 1).is_empty());
+    }
+
+    fn same_option_neighbors(
+        neighborhoods: &[RoutingOptionNeighborhood],
+        option: u32,
+        fallback_center_primary_cost: Option<f32>,
+    ) -> Vec<(ArrayIndex, f32)> {
+        let neighborhood = &neighborhoods[option as usize];
+        let Some(source_primary_cost) = neighborhood
+            .center_primary_cost
+            .or(fallback_center_primary_cost)
+        else {
+            return Vec::new();
+        };
+
+        neighborhood
+            .points
+            .iter()
+            .filter_map(|point| {
+                point
+                    .traversal_cost(source_primary_cost, 1.0, 1.0)
+                    .map(|cost| (point.destination.clone(), cost))
+            })
+            .collect()
     }
 }

--- a/crates/revrt/src/dataset/mod.rs
+++ b/crates/revrt/src/dataset/mod.rs
@@ -206,9 +206,9 @@ impl Dataset {
     }
 
     /// Return the center-cell entry cost for a single option state.
-    pub(super) fn get_cell_cost(&self, index: &ArrayIndex) -> Option<f32> {
+    pub(super) fn get_cell_cost_components(&self, index: &ArrayIndex) -> Option<(f32, f32)> {
         self.derived_data_reader
-            .get_cell_cost(index, &self.derived_data_writer)
+            .get_cell_cost_components(index, &self.derived_data_writer)
     }
 
     /// Return a single source-layer cell as `f32` for the requested index.

--- a/crates/revrt/src/dataset/mod.rs
+++ b/crates/revrt/src/dataset/mod.rs
@@ -87,6 +87,7 @@ impl NeighborhoodPoint {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct RoutingOptionNeighborhood {
+    pub(super) option: u32,
     pub(super) center_primary_cost: Option<f32>,
     pub(super) points: Vec<NeighborhoodPoint>,
 }
@@ -1136,7 +1137,9 @@ mod tests {
         option: u32,
         fallback_center_primary_cost: Option<f32>,
     ) -> Vec<(ArrayIndex, f32)> {
-        let neighborhood = &neighborhoods[option as usize];
+        let Some(neighborhood) = neighborhoods.iter().find(|item| item.option == option) else {
+            return Vec::new();
+        };
         let Some(source_primary_cost) = neighborhood
             .center_primary_cost
             .or(fallback_center_primary_cost)

--- a/crates/revrt/src/dataset/reader.rs
+++ b/crates/revrt/src/dataset/reader.rs
@@ -144,12 +144,15 @@ impl DerivedDataReader {
         })
     }
 
-    /// Read the valid 3x3 neighborhood movement costs around an index.
+    /// Read the clipped 3x3 neighborhood data for every routing option.
     ///
-    /// The returned costs combine the directional cost surface, the
-    /// invariant movement penalty, diagonal scaling, and optional hard
-    /// barrier filtering. If the center cell is itself a hard barrier,
-    /// an empty vector is returned.
+    /// The returned neighborhoods include the directional cost surface,
+    /// invariant movement penalty, and optional hard barrier state for
+    /// each neighboring cell in the clipped 3x3 window. The result always
+    /// contains one `RoutingOptionNeighborhood` per routing option. If a
+    /// center cell is blocked or otherwise invalid for an option, that
+    /// option's neighborhood is still returned with `center_primary_cost`
+    /// set to `None`.
     ///
     /// # Arguments
     /// `index`: Grid index whose neighborhood should be read.

--- a/crates/revrt/src/dataset/reader.rs
+++ b/crates/revrt/src/dataset/reader.rs
@@ -249,6 +249,7 @@ impl DerivedDataReader {
                     .collect::<Vec<_>>();
 
                 RoutingOptionNeighborhood {
+                    option: option_idx as u32,
                     center_primary_cost,
                     points,
                 }
@@ -757,6 +758,7 @@ mod tests {
         let neighbors = same_option_neighbors(&neighborhoods, index.option);
 
         assert_eq!(neighborhoods.len(), 2);
+        assert_eq!(neighborhoods[index.option as usize].option, 1);
         assert_eq!(
             neighborhoods[index.option as usize].center_primary_cost,
             Some(15.0)
@@ -809,6 +811,8 @@ mod tests {
         );
 
         assert_eq!(neighborhoods.len(), 2);
+        assert_eq!(neighborhoods[0].option, 0);
+        assert_eq!(neighborhoods[1].option, 1);
         assert_eq!(neighborhoods[0].center_primary_cost, Some(5.0));
         assert_eq!(neighborhoods[1].center_primary_cost, None);
         assert_eq!(neighborhoods[1].points.len(), 8);
@@ -1074,7 +1078,9 @@ mod tests {
         neighborhoods: &[RoutingOptionNeighborhood],
         option: u32,
     ) -> Vec<(ArrayIndex, f32)> {
-        let neighborhood = &neighborhoods[option as usize];
+        let Some(neighborhood) = neighborhoods.iter().find(|item| item.option == option) else {
+            return Vec::new();
+        };
         let Some(source_primary_cost) = neighborhood.center_primary_cost else {
             return Vec::new();
         };

--- a/crates/revrt/src/dataset/reader.rs
+++ b/crates/revrt/src/dataset/reader.rs
@@ -392,55 +392,53 @@ impl DerivedDataReader {
         (i_range, j_range, subset)
     }
 
-    /// Read cost values for every cell in a neighborhood subset.
+    /// Build the row and column ranges for a clipped 3x3 neighborhood.
     ///
-    /// When `is_invariant` is true, values are read from the invariant cost
-    /// array. Otherwise values are read from the primary cost array.
+    /// Unlike `neighborhood_subset`, the returned subset spans every routing
+    /// option on the leading band axis so callers can read all option bands in
+    /// a single cached request.
     ///
     /// # Arguments
-    /// `i_range`: Row indices covered by the neighborhood subset.
-    /// `j_range`: Column indices covered by the neighborhood subset.
-    /// `subset`: Swap-array subset to read from the selected cache.
-    /// `is_invariant`: Whether to read from the invariant cost cache instead
-    ///                 of the primary cost cache.
+    /// `index`: Center grid index for the requested neighborhood.
     ///
     /// # Returns
-    /// A vector pairing each neighborhood cell coordinate with the decoded
-    /// cost value read from the selected cache.
-    pub(super) fn get_neighbor_costs(
+    /// A tuple containing the clipped row range, clipped column range, and
+    /// the corresponding swap-array subset including all option bands.
+    fn neighborhood_subset_all_options(
         &self,
-        i_range: std::ops::Range<u64>,
-        j_range: std::ops::Range<u64>,
-        subset: &zarrs::array_subset::ArraySubset,
-        is_invariant: bool,
-    ) -> Vec<((u64, u64), f32)> {
-        trace!("Opening cost dataset (is_invariant={})", is_invariant);
+        index: &ArrayIndex,
+    ) -> (
+        std::ops::Range<u64>,
+        std::ops::Range<u64>,
+        zarrs::array_subset::ArraySubset,
+    ) {
+        let &ArrayIndex { i, j, .. } = index;
+        debug_assert!(self.grid_nrows > 0);
+        debug_assert!(self.grid_ncols > 0);
 
-        let cache = if is_invariant {
-            &self.cost_invariant_cache
-        } else {
-            &self.cost_cache
+        let max_i = self.grid_nrows - 1;
+        let max_j = self.grid_ncols - 1;
+
+        let i_range = match i {
+            0 if max_i == 0 => 0..1,
+            0 => 0..2,
+            _ if i == max_i => i - 1..i + 1,
+            _ => i - 1..i + 2,
         };
-        let cost_array = cache.array();
-        trace!(
-            "Cost dataset (is_invariant={}) with shape: {:?}",
-            is_invariant,
-            cost_array.shape()
-        );
+        let j_range = match j {
+            0 if max_j == 0 => 0..1,
+            0 => 0..2,
+            _ if j == max_j => j - 1..j + 1,
+            _ => j - 1..j + 2,
+        };
 
-        let cost_values: Vec<f32> = cache
-            .retrieve_array_subset_elements::<f32>(subset, &CodecOptions::default())
-            .unwrap();
+        let subset = zarrs::array_subset::ArraySubset::new_with_ranges(&[
+            0..u64::from(self.grid_noptions),
+            i_range.clone(),
+            j_range.clone(),
+        ]);
 
-        trace!("Read values {:?}", cost_values);
-
-        let neighbor_costs = i_range
-            .flat_map(|row| iter::repeat(row).zip(j_range.clone()))
-            .zip(cost_values)
-            .collect();
-
-        trace!("Neighbors {:?}", neighbor_costs);
-        neighbor_costs
+        (i_range, j_range, subset)
     }
 }
 

--- a/crates/revrt/src/dataset/reader.rs
+++ b/crates/revrt/src/dataset/reader.rs
@@ -294,11 +294,11 @@ impl DerivedDataReader {
     /// The returned value includes the length-dependent center-cell cost and
     /// the invariant adders for the destination option. Hard barriers and
     /// invalid costs return `None`.
-    pub(super) fn get_cell_cost(
+    pub(super) fn get_cell_cost_components(
         &self,
         index: &ArrayIndex,
         data_materializer: &impl DerivedDataMaterializer,
-    ) -> Option<f32> {
+    ) -> Option<(f32, f32)> {
         let subset = zarrs::array_subset::ArraySubset::new_with_ranges(&[
             u64::from(index.option)..u64::from(index.option) + 1,
             index.i..index.i + 1,
@@ -322,16 +322,17 @@ impl DerivedDataReader {
                 .next()?;
 
         if is_hard_barrier || cost.is_nan() || cost <= 0.0 {
-            None
-        } else {
-            let invariant = self
-                .cost_invariant_cache
-                .retrieve_array_subset_elements::<f32>(&subset, &CodecOptions::default())
-                .ok()?
-                .into_iter()
-                .next()?;
-            Some(cost + invariant)
+            return None;
         }
+
+        let invariant = self
+            .cost_invariant_cache
+            .retrieve_array_subset_elements::<f32>(&subset, &CodecOptions::default())
+            .ok()?
+            .into_iter()
+            .next()?;
+
+        Some((cost, invariant))
     }
 
     /// Return the grid shape backing this reader as `(rows, cols, options)`.
@@ -776,7 +777,7 @@ mod tests {
 
         let cost = fixture
             .reader
-            .get_cell_cost(
+            .get_cell_cost_components(
                 &ArrayIndex {
                     i: 1,
                     j: 0,
@@ -788,7 +789,38 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(cost, 31.0);
+        assert_eq!(cost.0 + cost.1, 31.0);
+    }
+
+    #[test]
+    fn get_cell_cost_components_split_primary_and_invariant_costs() {
+        let fixture = reader_fixture_with_shape(
+            2,
+            2,
+            2,
+            vec![1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0],
+            vec![0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0],
+            vec![false; 8],
+            vec![false; 8],
+            vec![false; 8],
+        );
+
+        let (primary_cost, invariant_cost) = fixture
+            .reader
+            .get_cell_cost_components(
+                &ArrayIndex {
+                    i: 1,
+                    j: 0,
+                    option: 1,
+                },
+                &NoOpMaterializer {
+                    has_hard_barriers: false,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(primary_cost, 30.0);
+        assert_eq!(invariant_cost, 1.0);
     }
 
     fn reader_for_grid(grid_nrows: u64, grid_ncols: u64) -> DerivedDataReader {

--- a/crates/revrt/src/dataset/reader.rs
+++ b/crates/revrt/src/dataset/reader.rs
@@ -14,6 +14,7 @@ use zarrs::storage::{ReadableStorageTraits, ReadableWritableListableStorage};
 
 use super::swap::SourceLayout;
 use super::swap::cumulative_soft_barrier_mask_name;
+use super::{NeighborhoodGeometry, NeighborhoodPoint, RoutingOptionNeighborhood};
 use crate::ArrayIndex;
 use crate::error::{Error, Result};
 
@@ -157,90 +158,102 @@ impl DerivedDataReader {
     ///                      before the cached read occurs.
     ///
     /// # Returns
-    /// A vector of reachable neighboring indices paired with movement costs
-    /// from the center cell to each neighbor.
-    pub(super) fn get_3x3(
+    /// A vector containing one `RoutingOptionNeighborhood` per routing option.
+    pub(super) fn get_3x3_neighborhood_all_options(
         &self,
         index: &ArrayIndex,
         data_materializer: &impl DerivedDataMaterializer,
-    ) -> Vec<(ArrayIndex, f32)> {
-        let &ArrayIndex { i, j, option } = index;
+    ) -> Vec<RoutingOptionNeighborhood> {
+        let &ArrayIndex { i: ci, j: cj, .. } = index;
 
         trace!(
-            "Getting 3x3 neighborhood for (i={}, j={}, option={})",
-            i, j, option
+            "Getting 3x3 neighborhood points for all options at (i={}, j={})",
+            ci, cj
         );
 
         trace!("Opening cost dataset via cache");
         let cost_array = self.cost_cache.array();
         trace!("Cost dataset with shape: {:?}", cost_array.shape());
 
-        let (i_range, j_range, subset) = self.neighborhood_subset(index);
+        let (i_range, j_range, subset) = self.neighborhood_subset_all_options(index);
         trace!("Cost subset: {:?}", subset);
         data_materializer.ensure_derived_data_for_subset(&cost_array, &subset);
 
-        let neighbors = self.get_neighbor_costs(i_range.clone(), j_range.clone(), &subset, false);
-        let invariant_neighbors =
-            self.get_neighbor_costs(i_range.clone(), j_range.clone(), &subset, true);
+        let primary_costs: Vec<f32> = self
+            .cost_cache
+            .retrieve_array_subset_elements::<f32>(&subset, &CodecOptions::default())
+            .unwrap();
+        let invariant_costs: Vec<f32> = self
+            .cost_invariant_cache
+            .retrieve_array_subset_elements::<f32>(&subset, &CodecOptions::default())
+            .unwrap();
         let hard_barrier_values: Vec<bool> = if data_materializer.has_hard_barriers() {
             self.hard_barrier_cache
                 .retrieve_array_subset_elements::<bool>(&subset, &CodecOptions::default())
                 .unwrap()
         } else {
-            std::iter::repeat_n(false, neighbors.len()).collect()
+            std::iter::repeat_n(false, primary_costs.len()).collect()
         };
 
-        let center = neighbors
+        let ij_coordinates = i_range
+            .clone()
+            .flat_map(|row| iter::repeat(row).zip(j_range.clone()))
+            .collect::<Vec<(u64, u64)>>();
+        let per_option_len = ij_coordinates.len();
+        let center_index = ij_coordinates
             .iter()
-            .zip(hard_barrier_values.iter())
-            .find(|(((ir, jr), _), _)| *ir == i && *jr == j)
-            .map(|(((ir, jr), v), is_barrier)| {
-                if *is_barrier {
-                    ((ir, jr), &0_f32, true)
-                } else if v.is_nan() {
-                    ((ir, jr), &0_f32, false)
-                } else {
-                    ((ir, jr), v, false)
-                }
-            })
+            .position(|(row, col)| *row == ci && *col == cj)
             .unwrap();
 
-        if center.2 {
-            // center cell is barrier, so no neighbors
-            return Vec::new();
-        }
-        trace!("Center point: {:?}", center);
-
-        let cost_to_neighbors = neighbors
-            .iter()
-            .zip(invariant_neighbors.iter())
-            .zip(hard_barrier_values.iter())
-            .filter(|((((ir, jr), v), _), is_barrier)| {
-                !(**is_barrier || v.is_nan() || (*ir == i && *jr == j))
-            })
-            .map(|((((ir, jr), v), ((inv_ir, inv_jr), inv_cost)), _)| {
-                debug_assert_eq!((ir, jr), (inv_ir, inv_jr));
-                ((ir, jr), 0.5 * (v + center.1), inv_cost)
-            })
-            .map(|((ir, jr), v, inv_cost)| {
-                let scaled = if *ir != i && *jr != j {
-                    v * f32::sqrt(2.0)
+        (0..self.grid_noptions as usize)
+            .map(|option_idx| {
+                let offset = option_idx * per_option_len;
+                let primary_slice = &primary_costs[offset..offset + per_option_len];
+                let invariant_slice = &invariant_costs[offset..offset + per_option_len];
+                let hard_barrier_slice = &hard_barrier_values[offset..offset + per_option_len];
+                let center_primary_cost = if hard_barrier_slice[center_index]
+                    || primary_slice[center_index].is_nan()
+                    || primary_slice[center_index] <= 0.0
+                {
+                    None
                 } else {
-                    v
+                    Some(primary_slice[center_index])
                 };
-                (
-                    ArrayIndex {
-                        i: *ir,
-                        j: *jr,
-                        option,
-                    },
-                    scaled + inv_cost,
-                )
-            })
-            .collect::<Vec<_>>();
 
-        trace!("Neighbors {:?}", cost_to_neighbors);
-        cost_to_neighbors
+                let points = ij_coordinates
+                    .iter()
+                    .zip(primary_slice.iter())
+                    .zip(invariant_slice.iter())
+                    .zip(hard_barrier_slice.iter())
+                    .enumerate()
+                    .filter(|(cell_index, _)| *cell_index != center_index)
+                    .map(
+                        |(_, ((((row, col), primary_cost), invariant_cost), is_barrier))| {
+                            NeighborhoodPoint {
+                                destination: ArrayIndex {
+                                    i: *row,
+                                    j: *col,
+                                    option: option_idx as u32,
+                                },
+                                geometry: if *row != ci && *col != cj {
+                                    NeighborhoodGeometry::Corner
+                                } else {
+                                    NeighborhoodGeometry::Side
+                                },
+                                destination_primary_cost: *primary_cost,
+                                destination_invariant_cost: *invariant_cost,
+                                destination_is_hard_barrier: *is_barrier,
+                            }
+                        },
+                    )
+                    .collect::<Vec<_>>();
+
+                RoutingOptionNeighborhood {
+                    center_primary_cost,
+                    points,
+                }
+            })
+            .collect()
     }
 
     /// Return soft barrier cells in the 3x3 neighborhood for a retry state.
@@ -570,12 +583,14 @@ mod tests {
             vec![true, false, false, false, false, false, false, true, false],
         );
 
-        let neighbors = fixture.reader.get_3x3(
-            &ArrayIndex::new_ij(1, 1),
+        let index = ArrayIndex::new_ij(1, 1);
+        let neighborhoods = fixture.reader.get_3x3_neighborhood_all_options(
+            &index,
             &NoOpMaterializer {
                 has_hard_barriers: true,
             },
         );
+        let neighbors = same_option_neighbors(&neighborhoods, index.option);
 
         let expected = [
             (ArrayIndex::new_ij(0, 0), 3.0 * SQRT_2 + 1.0),
@@ -605,14 +620,20 @@ mod tests {
             vec![false; 9],
         );
 
-        let neighbors = fixture.reader.get_3x3(
-            &ArrayIndex::new_ij(1, 1),
+        let index = ArrayIndex::new_ij(1, 1);
+        let neighborhoods = fixture.reader.get_3x3_neighborhood_all_options(
+            &index,
             &NoOpMaterializer {
                 has_hard_barriers: true,
             },
         );
+        let neighbors = same_option_neighbors(&neighborhoods, index.option);
 
         assert!(neighbors.is_empty());
+        assert_eq!(
+            neighborhoods[index.option as usize].center_primary_cost,
+            None
+        );
     }
 
     #[test]
@@ -626,18 +647,27 @@ mod tests {
         );
         let index = ArrayIndex::new_ij(1, 1);
 
-        let (i_range, j_range, subset) = fixture.reader.neighborhood_subset(&index);
-        let raw_costs = fixture
-            .reader
-            .get_neighbor_costs(i_range, j_range, &subset, false);
-        let neighbors = fixture.reader.get_3x3(
+        let neighborhoods = fixture.reader.get_3x3_neighborhood_all_options(
             &index,
             &NoOpMaterializer {
                 has_hard_barriers: true,
             },
         );
+        let option_neighborhood = &neighborhoods[index.option as usize];
+        let neighbors = same_option_neighbors(&neighborhoods, index.option);
 
-        assert_eq!(raw_costs.len(), 9);
+        let raw_costs = option_neighborhood
+            .points
+            .iter()
+            .map(|point| {
+                (
+                    (point.destination.i, point.destination.j),
+                    point.destination_primary_cost,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(option_neighborhood.center_primary_cost, Some(5.0));
         assert_eq!(
             raw_costs,
             vec![
@@ -645,7 +675,6 @@ mod tests {
                 ((0, 1), 2.0),
                 ((0, 2), 3.0),
                 ((1, 0), 4.0),
-                ((1, 1), 5.0),
                 ((1, 2), 6.0),
                 ((2, 0), 7.0),
                 ((2, 1), 8.0),
@@ -714,18 +743,29 @@ mod tests {
             vec![false; 18],
         );
 
-        let neighbors = fixture.reader.get_3x3(
-            &ArrayIndex {
-                i: 1,
-                j: 1,
-                option: 1,
-            },
+        let index = ArrayIndex {
+            i: 1,
+            j: 1,
+            option: 1,
+        };
+        let neighborhoods = fixture.reader.get_3x3_neighborhood_all_options(
+            &index,
             &NoOpMaterializer {
                 has_hard_barriers: false,
             },
         );
+        let neighbors = same_option_neighbors(&neighborhoods, index.option);
 
-        assert!(neighbors.iter().all(|(index, _)| index.option == 1));
+        assert_eq!(neighborhoods.len(), 2);
+        assert_eq!(
+            neighborhoods[index.option as usize].center_primary_cost,
+            Some(15.0)
+        );
+        assert!(
+            neighbors
+                .iter()
+                .all(|(neighbor_index, _)| neighbor_index.option == 1)
+        );
         assert!(neighbors.contains(&(
             ArrayIndex {
                 i: 0,
@@ -738,10 +778,49 @@ mod tests {
             ArrayIndex {
                 i: 1,
                 j: 2,
-                option: 1
+                option: 1,
             },
             15.5
         )));
+    }
+
+    #[test]
+    fn get_3x3_neighborhood_all_options_reads_each_option_once_and_keeps_points_for_blocked_centers()
+     {
+        let fixture = reader_fixture_with_shape(
+            2,
+            3,
+            3,
+            vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 11.0, 12.0, 13.0, 14.0, -1.0, 16.0,
+                17.0, 18.0, 19.0,
+            ],
+            vec![0.0; 18],
+            vec![false; 18],
+            vec![false; 18],
+            vec![false; 18],
+        );
+
+        let neighborhoods = fixture.reader.get_3x3_neighborhood_all_options(
+            &ArrayIndex::new_ij(1, 1),
+            &NoOpMaterializer {
+                has_hard_barriers: false,
+            },
+        );
+
+        assert_eq!(neighborhoods.len(), 2);
+        assert_eq!(neighborhoods[0].center_primary_cost, Some(5.0));
+        assert_eq!(neighborhoods[1].center_primary_cost, None);
+        assert_eq!(neighborhoods[1].points.len(), 8);
+        assert!(neighborhoods[1].points.iter().any(|point| {
+            point.destination
+                == ArrayIndex {
+                    i: 1,
+                    j: 2,
+                    option: 1,
+                }
+                && point.destination_primary_cost == 16.0
+        }));
     }
 
     #[test]
@@ -989,6 +1068,26 @@ mod tests {
             0..chunk_grid_shape[1],
             0..chunk_grid_shape[2],
         ])
+    }
+
+    fn same_option_neighbors(
+        neighborhoods: &[RoutingOptionNeighborhood],
+        option: u32,
+    ) -> Vec<(ArrayIndex, f32)> {
+        let neighborhood = &neighborhoods[option as usize];
+        let Some(source_primary_cost) = neighborhood.center_primary_cost else {
+            return Vec::new();
+        };
+
+        neighborhood
+            .points
+            .iter()
+            .filter_map(|point| {
+                point
+                    .traversal_cost(source_primary_cost, 1.0, 1.0)
+                    .map(|cost| (point.destination.clone(), cost))
+            })
+            .collect()
     }
 
     struct ReaderFixture {

--- a/crates/revrt/src/routing/mod.rs
+++ b/crates/revrt/src/routing/mod.rs
@@ -335,6 +335,14 @@ mod tests {
         if band == 0 { 1.0 } else { 4.0 }
     }
 
+    fn first_option_destination_barrier(band: u64, row: u64, col: u64) -> f32 {
+        if band == 0 && row == 0 && col == 1 {
+            1.0
+        } else {
+            0.0
+        }
+    }
+
     #[test]
     fn compute_route_attempt_result_tracks_dropped_barriers_per_start() {
         let store = crate::dataset::samples::ZarrTestBuilder::new()
@@ -410,13 +418,17 @@ mod tests {
     }
 
     #[test]
-    fn compute_route_attempt_result_can_switch_options_in_place() {
+    fn compute_route_attempt_result_can_switch_options_while_moving() {
         let store = crate::dataset::samples::ZarrTestBuilder::new()
-            .dimensions(2, 1, 1)
-            .chunks(2, 1, 1)
+            .dimensions(2, 1, 2)
+            .chunks(2, 1, 2)
             .layer(crate::dataset::samples::LayerConfig::custom(
                 "cost",
                 layered_switch_cost,
+            ))
+            .layer(crate::dataset::samples::LayerConfig::custom(
+                "hard_barrier",
+                first_option_destination_barrier,
             ))
             .build()
             .unwrap();
@@ -424,10 +436,24 @@ mod tests {
             r#"{
                 "routing_options": {
                     "overhead": {
-                        "cost_layers": [{"layer_name": "cost"}]
+                        "cost_layers": [{"layer_name": "cost"}],
+                        "barrier_layers": [
+                            {
+                                "layer_name": "hard_barrier",
+                                "barrier_operator": "eq",
+                                "barrier_threshold": 1.0
+                            }
+                        ]
                     },
                     "underground": {
-                        "cost_layers": [{"layer_name": "cost"}]
+                        "cost_layers": [{"layer_name": "cost"}],
+                        "barrier_layers": [
+                            {
+                                "layer_name": "hard_barrier",
+                                "barrier_operator": "eq",
+                                "barrier_threshold": 1.0
+                            }
+                        ]
                     }
                 },
                 "ignore_invalid_costs": false
@@ -441,11 +467,7 @@ mod tests {
             j: 0,
             option: 0,
         }];
-        let end = [ArrayIndex {
-            i: 0,
-            j: 0,
-            option: 1,
-        }];
+        let end = [ArrayIndex::new_ij(0, 1)];
 
         let result = compute_route_attempt_result(&scenario, &algorithm, &start, &end);
 
@@ -460,22 +482,26 @@ mod tests {
                 },
                 ArrayIndex {
                     i: 0,
-                    j: 0,
+                    j: 1,
                     option: 1
                 },
             ]
         );
-        assert_eq!(*result[0].total_cost(), 4.0);
+        assert_eq!(*result[0].total_cost(), 2.5);
     }
 
     #[test]
     fn compute_route_attempt_result_applies_transition_costs() {
         let store = crate::dataset::samples::ZarrTestBuilder::new()
-            .dimensions(2, 1, 1)
-            .chunks(2, 1, 1)
+            .dimensions(2, 1, 2)
+            .chunks(2, 1, 2)
             .layer(crate::dataset::samples::LayerConfig::custom(
                 "cost",
                 layered_switch_cost,
+            ))
+            .layer(crate::dataset::samples::LayerConfig::custom(
+                "hard_barrier",
+                first_option_destination_barrier,
             ))
             .build()
             .unwrap();
@@ -483,10 +509,24 @@ mod tests {
             r#"{
                 "routing_options": {
                     "overhead": {
-                        "cost_layers": [{"layer_name": "cost"}]
+                        "cost_layers": [{"layer_name": "cost"}],
+                        "barrier_layers": [
+                            {
+                                "layer_name": "hard_barrier",
+                                "barrier_operator": "eq",
+                                "barrier_threshold": 1.0
+                            }
+                        ]
                     },
                     "underground": {
-                        "cost_layers": [{"layer_name": "cost"}]
+                        "cost_layers": [{"layer_name": "cost"}],
+                        "barrier_layers": [
+                            {
+                                "layer_name": "hard_barrier",
+                                "barrier_operator": "eq",
+                                "barrier_threshold": 1.0
+                            }
+                        ]
                     }
                 },
                 "transition_costs": {
@@ -509,16 +549,85 @@ mod tests {
             j: 0,
             option: 0,
         }];
-        let end = [ArrayIndex {
-            i: 0,
-            j: 0,
-            option: 1,
-        }];
+        let end = [ArrayIndex::new_ij(0, 1)];
 
         let result = compute_route_attempt_result(&scenario, &algorithm, &start, &end);
 
         assert_eq!(result.len(), 1);
-        assert_eq!(*result[0].total_cost(), 7.0);
+        assert_eq!(*result[0].total_cost(), 5.5);
+    }
+
+    #[test]
+    fn compute_route_attempt_result_can_end_on_any_allowed_option() {
+        let store = crate::dataset::samples::ZarrTestBuilder::new()
+            .dimensions(2, 1, 2)
+            .chunks(2, 1, 2)
+            .layer(crate::dataset::samples::LayerConfig::custom(
+                "cost",
+                layered_switch_cost,
+            ))
+            .layer(crate::dataset::samples::LayerConfig::custom(
+                "hard_barrier",
+                first_option_destination_barrier,
+            ))
+            .build()
+            .unwrap();
+        let cost_function = crate::cost::CostFunction::from_json(
+            r#"{
+                "routing_options": {
+                    "overhead": {
+                        "cost_layers": [{"layer_name": "cost"}],
+                        "barrier_layers": [
+                            {
+                                "layer_name": "hard_barrier",
+                                "barrier_operator": "eq",
+                                "barrier_threshold": 1.0
+                            }
+                        ]
+                    },
+                    "underground": {
+                        "cost_layers": [{"layer_name": "cost"}],
+                        "barrier_layers": [
+                            {
+                                "layer_name": "hard_barrier",
+                                "barrier_operator": "eq",
+                                "barrier_threshold": 1.0
+                            }
+                        ]
+                    }
+                },
+                "ignore_invalid_costs": false
+            }"#,
+        )
+        .unwrap();
+        let scenario = Scenario::new(store.path(), cost_function, 1_000).unwrap();
+        let algorithm = Algorithm::from_selection(AlgorithmType::Dijkstra, 8 * 1024 * 1024);
+        let start = [ArrayIndex {
+            i: 0,
+            j: 0,
+            option: 1,
+        }];
+        let end = [ArrayIndex::new_ij(0, 1)];
+
+        let result = compute_route_attempt_result(&scenario, &algorithm, &start, &end);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].route(),
+            &vec![
+                ArrayIndex {
+                    i: 0,
+                    j: 0,
+                    option: 1
+                },
+                ArrayIndex {
+                    i: 0,
+                    j: 1,
+                    option: 1
+                },
+            ]
+        );
+        assert_eq!(*result[0].total_cost(), 4.0);
     }
 
     // fn any_option_start_cost(band: u64, _row: u64, _col: u64) -> f32 {

--- a/crates/revrt/src/routing/mod.rs
+++ b/crates/revrt/src/routing/mod.rs
@@ -227,7 +227,7 @@ fn compute_solution_for_start(
             &start_point,
             end,
             |p| scenario.successors_for_attempt(p, dropped_soft_groups),
-            |p| end.contains(p),
+            |p| end.contains(p), // |p| end.iter().any(|goal| goal.i == p.i && goal.j == p.j),
             grid_shape,
         );
 
@@ -467,7 +467,11 @@ mod tests {
             j: 0,
             option: 0,
         }];
-        let end = [ArrayIndex::new_ij(0, 1)];
+        let end = [ArrayIndex {
+            i: 0,
+            j: 1,
+            option: 1,
+        }];
 
         let result = compute_route_attempt_result(&scenario, &algorithm, &start, &end);
 
@@ -549,7 +553,11 @@ mod tests {
             j: 0,
             option: 0,
         }];
-        let end = [ArrayIndex::new_ij(0, 1)];
+        let end = [ArrayIndex {
+            i: 0,
+            j: 1,
+            option: 1,
+        }];
 
         let result = compute_route_attempt_result(&scenario, &algorithm, &start, &end);
 
@@ -558,7 +566,7 @@ mod tests {
     }
 
     #[test]
-    fn compute_route_attempt_result_can_end_on_any_allowed_option() {
+    fn compute_route_attempt_result_requires_matching_end_option() {
         let store = crate::dataset::samples::ZarrTestBuilder::new()
             .dimensions(2, 1, 2)
             .chunks(2, 1, 2)
@@ -607,7 +615,11 @@ mod tests {
             j: 0,
             option: 1,
         }];
-        let end = [ArrayIndex::new_ij(0, 1)];
+        let end = [ArrayIndex {
+            i: 0,
+            j: 1,
+            option: 1,
+        }];
 
         let result = compute_route_attempt_result(&scenario, &algorithm, &start, &end);
 

--- a/crates/revrt/src/routing/scenario.rs
+++ b/crates/revrt/src/routing/scenario.rs
@@ -139,7 +139,9 @@ impl Scenario {
         }
 
         let option_neighborhoods = self.dataset.get_3x3_neighborhood_all_options(position);
-        let Some(current_option_neighborhood) = option_neighborhoods.get(position.option as usize)
+        let Some(current_option_neighborhood) = option_neighborhoods
+            .iter()
+            .find(|item| item.option == position.option)
         else {
             return Vec::new();
         };
@@ -152,8 +154,8 @@ impl Scenario {
 
         let mut neighbors = Vec::new();
 
-        for (option, option_neighborhood) in option_neighborhoods.iter().enumerate() {
-            let option = option as u32;
+        for option_neighborhood in &option_neighborhoods {
+            let option = option_neighborhood.option;
             if option == position.option {
                 neighbors.extend(self.same_option_successors(
                     &option_neighborhood.points,

--- a/crates/revrt/src/routing/scenario.rs
+++ b/crates/revrt/src/routing/scenario.rs
@@ -19,6 +19,7 @@ use tracing::trace;
 
 use super::cost_as_u64;
 use crate::cost::components::{DriverRuleSet, TransitionCostTable};
+use crate::dataset::NeighborhoodPoint;
 use crate::routing::features::Features;
 use crate::{ArrayIndex, Result};
 
@@ -127,7 +128,6 @@ impl Scenario {
         position: &ArrayIndex,
         dropped_soft_groups: usize,
     ) -> Vec<(ArrayIndex, u64)> {
-        let spatial_neighbors = self.dataset.get_3x3(position);
         let soft_barrier_cells: HashSet<_> = self
             .dataset
             .get_3x3_soft_barrier_cells(position, dropped_soft_groups)
@@ -138,56 +138,106 @@ impl Scenario {
             return Vec::new();
         }
 
-        if self.driver_multiplier(position).is_none() {
+        let option_neighborhoods = self.dataset.get_3x3_neighborhood_all_options(position);
+        let Some(current_option_neighborhood) = option_neighborhoods.get(position.option as usize)
+        else {
             return Vec::new();
-        }
+        };
+        let Some(source_primary_cost) = current_option_neighborhood.center_primary_cost else {
+            return Vec::new();
+        };
+        let Some(source_driver_multiplier) = self.driver_multiplier(position) else {
+            return Vec::new();
+        };
 
-        let mut neighbors = spatial_neighbors
-            .into_iter()
-            .filter(|(p, c)| c.is_finite() && *c > 0.0 && !soft_barrier_cells.contains(p))
-            .filter_map(|(p, c)| {
-                self.driver_multiplier(&p)
-                    .map(|multiplier| (p, cost_as_u64(c * multiplier)))
-            })
-            .collect::<Vec<_>>();
+        let mut neighbors = Vec::new();
 
-        let (_, _, noptions) = self.grid_shape();
-        for option in 0..noptions {
+        for (option, option_neighborhood) in option_neighborhoods.iter().enumerate() {
+            let option = option as u32;
             if option == position.option {
-                continue;
+                neighbors.extend(self.same_option_successors(
+                    &option_neighborhood.points,
+                    source_primary_cost,
+                    &soft_barrier_cells,
+                ));
+            } else {
+                let destination_soft_barriers: HashSet<_> = self
+                    .dataset
+                    .get_3x3_soft_barrier_cells(
+                        &ArrayIndex {
+                            i: position.i,
+                            j: position.j,
+                            option,
+                        },
+                        dropped_soft_groups,
+                    )
+                    .into_iter()
+                    .collect();
+
+                neighbors.extend(self.switched_option_successors(
+                    position.option,
+                    &option_neighborhood.points,
+                    source_primary_cost,
+                    source_driver_multiplier,
+                    &destination_soft_barriers,
+                ));
             }
-
-            let destination = ArrayIndex {
-                i: position.i,
-                j: position.j,
-                option,
-            };
-            let destination_soft_barriers: HashSet<_> = self
-                .dataset
-                .get_3x3_soft_barrier_cells(&destination, dropped_soft_groups)
-                .into_iter()
-                .collect();
-            if destination_soft_barriers.contains(&destination) {
-                continue;
-            }
-
-            let Some(destination_center_cost) = self.dataset.get_cell_cost(&destination) else {
-                continue; // destination is hard barriered
-            };
-            let Some(driver_multiplier) = self.driver_multiplier(&destination) else {
-                continue; // destination is excluded by the driver
-            };
-
-            let transition_cost = self.transition_cost(position.option, option);
-            neighbors.push((
-                destination,
-                transition_cost
-                    .saturating_add(cost_as_u64(destination_center_cost * driver_multiplier)),
-            ));
         }
 
         trace!("Adjusting neighbors' types: {:?}", neighbors);
         neighbors
+    }
+
+    fn same_option_successors(
+        &self,
+        points: &[NeighborhoodPoint],
+        source_primary_cost: f32,
+        soft_barrier_cells: &HashSet<ArrayIndex>,
+    ) -> Vec<(ArrayIndex, u64)> {
+        points
+            .iter()
+            .filter(|point| !soft_barrier_cells.contains(&point.destination))
+            .filter_map(|point| {
+                let multiplier = self.driver_multiplier(&point.destination)?;
+                point
+                    .traversal_cost(source_primary_cost, multiplier, multiplier)
+                    .filter(|cost| cost.is_finite() && *cost > 0.0)
+                    .map(|cost| (point, cost))
+            })
+            .map(|(point, cost)| (point.destination.clone(), cost_as_u64(cost)))
+            .collect()
+    }
+
+    fn switched_option_successors(
+        &self,
+        from_option: u32,
+        points: &[NeighborhoodPoint],
+        source_primary_cost: f32,
+        source_driver_multiplier: f32,
+        soft_barrier_cells: &HashSet<ArrayIndex>,
+    ) -> Vec<(ArrayIndex, u64)> {
+        points
+            .iter()
+            .filter(|point| !soft_barrier_cells.contains(&point.destination))
+            .filter_map(|point| {
+                let destination_driver_multiplier = self.driver_multiplier(&point.destination)?;
+                point
+                    .traversal_cost(
+                        source_primary_cost,
+                        source_driver_multiplier,
+                        destination_driver_multiplier,
+                    )
+                    .filter(|cost| cost.is_finite() && *cost > 0.0)
+                    .map(|cost| (point, cost))
+            })
+            .map(|(point, traversal_cost)| {
+                (
+                    point.destination.clone(),
+                    self.transition_cost(from_option, point.destination.option)
+                        .saturating_add(cost_as_u64(traversal_cost)),
+                )
+            })
+            .collect()
     }
 
     /// Count the configured soft barrier groups.
@@ -259,7 +309,7 @@ impl Scenario {
             }
 
             self.dataset
-                .get_cell_cost(&candidate) // checks for hard barriers
+                .get_cell_cost_components(&candidate) // checks for hard barriers
                 .filter(|_| self.driver_multiplier(&candidate).is_some()) // drops `None` values from `get_cell_cost`
                 .map(|_| candidate) // drops `None` values from `driver_multiplier`
         })
@@ -311,8 +361,8 @@ mod tests {
         if band == 0 { 1.0 } else { 5.0 }
     }
 
-    fn second_option_center_barrier(band: u64, row: u64, col: u64) -> f32 {
-        if band == 1 && row == 1 && col == 1 {
+    fn second_option_right_barrier(band: u64, row: u64, col: u64) -> f32 {
+        if band == 1 && row == 1 && col == 2 {
             1.0
         } else {
             0.0
@@ -329,6 +379,14 @@ mod tests {
 
     fn underground_option_cost(band: u64, _row: u64, _col: u64) -> f32 {
         if band == 1 { 5.0 } else { 8.0 }
+    }
+
+    fn constant_positive_cost(_band: u64, _row: u64, _col: u64) -> f32 {
+        1.0
+    }
+
+    fn constant_zone(_band: u64, _row: u64, _col: u64) -> f32 {
+        1.0
     }
 
     #[test]
@@ -444,7 +502,7 @@ mod tests {
     }
 
     #[test]
-    fn successors_include_same_pixel_option_transitions() {
+    fn successors_include_directional_option_transitions() {
         let store = crate::dataset::samples::ZarrTestBuilder::new()
             .dimensions(2, 3, 3)
             .chunks(2, 3, 3)
@@ -483,15 +541,70 @@ mod tests {
             *index
                 == ArrayIndex {
                     i: 1,
-                    j: 1,
+                    j: 2,
                     option: 1,
                 }
-                && *cost == 50_000
+                && *cost == 30_000
+        }));
+        assert!(!successors.iter().any(|(index, _)| *index
+            == ArrayIndex {
+                i: 1,
+                j: 1,
+                option: 1,
+            }));
+    }
+
+    #[test]
+    fn successors_use_corner_geometry_for_directional_option_transitions() {
+        let store = crate::dataset::samples::ZarrTestBuilder::new()
+            .dimensions(2, 3, 3)
+            .chunks(2, 3, 3)
+            .layer(crate::dataset::samples::LayerConfig::custom(
+                "cost",
+                option_cost,
+            ))
+            .build()
+            .unwrap();
+        let cost_function = crate::cost::CostFunction::from_json(
+            r#"{
+                "routing_options": {
+                    "overhead": {
+                        "cost_layers": [{"layer_name": "cost"}]
+                    },
+                    "underground": {
+                        "cost_layers": [{"layer_name": "cost"}]
+                    }
+                },
+                "ignore_invalid_costs": false
+            }"#,
+        )
+        .unwrap();
+        let scenario = Scenario::new(store.path(), cost_function, 1_000).unwrap();
+
+        let successors = scenario.successors_for_attempt(
+            &ArrayIndex {
+                i: 1,
+                j: 1,
+                option: 0,
+            },
+            0,
+        );
+
+        let expected_cost = (((1.0 + 5.0) * f32::sqrt(2.0)) / 2.0 * 10_000.0) as u64;
+
+        assert!(successors.iter().any(|(index, cost)| {
+            *index
+                == ArrayIndex {
+                    i: 2,
+                    j: 2,
+                    option: 1,
+                }
+                && *cost == expected_cost
         }));
     }
 
     #[test]
-    fn successors_skip_same_pixel_transitions_into_blocked_options() {
+    fn successors_skip_directional_option_transitions_into_blocked_options() {
         let store = crate::dataset::samples::ZarrTestBuilder::new()
             .dimensions(2, 3, 3)
             .chunks(2, 3, 3)
@@ -501,7 +614,7 @@ mod tests {
             ))
             .layer(crate::dataset::samples::LayerConfig::custom(
                 "hard_barrier",
-                second_option_center_barrier,
+                second_option_right_barrier,
             ))
             .build()
             .unwrap();
@@ -547,7 +660,7 @@ mod tests {
         assert!(!successors.iter().any(|(index, _)| *index
             == ArrayIndex {
                 i: 1,
-                j: 1,
+                j: 2,
                 option: 1
             }));
     }
@@ -603,10 +716,10 @@ mod tests {
             *index
                 == ArrayIndex {
                     i: 1,
-                    j: 1,
+                    j: 2,
                     option: 1,
                 }
-                && *cost == 80_000
+                && *cost == 60_000
         }));
     }
 
@@ -664,10 +777,10 @@ mod tests {
             *index
                 == ArrayIndex {
                     i: 1,
-                    j: 1,
+                    j: 2,
                     option: 1,
                 }
-                && *cost == 80_000
+                && *cost == 60_000
         }));
     }
 
@@ -806,6 +919,130 @@ mod tests {
                 }
                 && *cost == 100_000
         }));
+    }
+
+    #[test]
+    fn successors_apply_driver_multipliers_to_switched_moves() {
+        let store = crate::dataset::samples::ZarrTestBuilder::new()
+            .dimensions(2, 3, 3)
+            .chunks(2, 3, 3)
+            .layer(crate::dataset::samples::LayerConfig::custom(
+                "cost",
+                option_cost,
+            ))
+            .layer(crate::dataset::samples::LayerConfig::custom(
+                "zone",
+                |_band, row, col| option_zone(row, col),
+            ))
+            .build()
+            .unwrap();
+        let cost_function = crate::cost::CostFunction::from_json(
+            r#"{
+                "routing_options": {
+                    "overhead": {
+                        "cost_layers": [{"layer_name": "cost"}]
+                    },
+                    "underground": {
+                        "cost_layers": [{"layer_name": "cost"}]
+                    }
+                },
+                "drivers": {
+                    "default": {
+                        "overhead": 1,
+                        "underground": 1
+                    },
+                    "zones": [
+                        {
+                            "layer_name": "zone",
+                            "mask_operator": "eq",
+                            "mask_threshold": 1,
+                            "overhead": 10,
+                            "underground": 1
+                        }
+                    ]
+                },
+                "ignore_invalid_costs": false
+            }"#,
+        )
+        .unwrap();
+        let scenario = Scenario::new(store.path(), cost_function, 1_000).unwrap();
+
+        let successors = scenario.successors_for_attempt(
+            &ArrayIndex {
+                i: 1,
+                j: 1,
+                option: 0,
+            },
+            0,
+        );
+
+        assert!(successors.iter().any(|(index, cost)| {
+            *index
+                == ArrayIndex {
+                    i: 1,
+                    j: 2,
+                    option: 1,
+                }
+                && *cost == 75_000
+        }));
+    }
+
+    #[test]
+    fn successors_skip_switched_moves_with_nonpositive_traversal_costs() {
+        let store = crate::dataset::samples::ZarrTestBuilder::new()
+            .dimensions(2, 3, 3)
+            .chunks(2, 3, 3)
+            .layer(crate::dataset::samples::LayerConfig::custom(
+                "cost",
+                constant_positive_cost,
+            ))
+            .layer(crate::dataset::samples::LayerConfig::custom(
+                "zone",
+                constant_zone,
+            ))
+            .build()
+            .unwrap();
+        let cost_function = crate::cost::CostFunction::from_json(
+            r#"{
+                "routing_options": {
+                    "overhead": {
+                        "cost_layers": [{"layer_name": "cost"}]
+                    },
+                    "underground": {
+                        "cost_layers": [{"layer_name": "cost"}]
+                    }
+                },
+                "drivers": {
+                    "default": {
+                        "overhead": 1,
+                        "underground": 1
+                    },
+                    "zones": [
+                        {
+                            "layer_name": "zone",
+                            "mask_operator": "eq",
+                            "mask_threshold": 1,
+                            "overhead": 0,
+                            "underground": 0
+                        }
+                    ]
+                },
+                "ignore_invalid_costs": false
+            }"#,
+        )
+        .unwrap();
+        let scenario = Scenario::new(store.path(), cost_function, 1_000).unwrap();
+
+        let successors = scenario.successors_for_attempt(
+            &ArrayIndex {
+                i: 1,
+                j: 1,
+                option: 0,
+            },
+            0,
+        );
+
+        assert!(successors.is_empty());
     }
 
     #[test]

--- a/pixi.lock
+++ b/pixi.lock
@@ -2871,7 +2871,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -3151,7 +3151,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -3649,7 +3649,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -4150,7 +4150,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -5928,7 +5928,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -6070,7 +6070,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -6405,7 +6405,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -6740,7 +6740,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -13658,17 +13658,17 @@ packages:
   - pkg:pypi/pysocks?source=hash-mapping
   size: 21085
   timestamp: 1733217331982
-- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
-  sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
-  md5: 6a991452eadf2771952f39d43615bb3e
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
+  sha256: 39f41a52eb6f927caf5cd42a2ff98a09bb850ce9758b432869374b6253826962
+  md5: da0c42269086f5170e2b296878ec13a6
   depends:
-  - colorama >=0.4
   - pygments >=2.7.2
   - python >=3.10
-  - iniconfig >=1.0.1
-  - packaging >=22
+  - iniconfig >=1
+  - packaging >=20
   - pluggy >=1.5,<2
   - tomli >=1
+  - colorama >=0.4
   - exceptiongroup >=1
   - python
   constrains:
@@ -13676,9 +13676,9 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pytest?source=compressed-mapping
-  size: 299984
-  timestamp: 1775644472530
+  - pkg:pypi/pytest?source=hash-mapping
+  size: 294852
+  timestamp: 1762354779909
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.10.1-pyhd8ed1ab_0.conda
   sha256: 1b685d7bb59585807ef612cfc4d1be6a082326b1a1d445a0de893f3d2aa20c3d
   md5: 315adb19d68b8a050f8f330cb8adfc24
@@ -24632,7 +24632,7 @@ packages:
   - ruff>=0.15.15 ; extra == 'dev'
   - ruff-lsp>=0.0.62 ; extra == 'dev'
   - hypothesis>=6.152.1,<7 ; extra == 'test'
-  - pytest>=9.0.3,<10 ; extra == 'test'
+  - pytest>=8.0,<9 ; extra == 'test'
   - pytest-cases>=3.10.1,<4 ; extra == 'test'
   - pytest-cov>=7.1.0,<8 ; extra == 'test'
   - pytest-mock>=3.15.1,<4 ; extra == 'test'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev = [
 ]
 test = [
   "hypothesis>=6.152.1,<7",
-  "pytest>=9.0.3,<10",
+  "pytest>=8.0,<9",
   "pytest-cases>=3.10.1,<4",
   "pytest-cov>=7.1.0,<8",
   "pytest-mock>=3.15.1,<4",
@@ -301,7 +301,7 @@ maturin = ">=1.13.1,<2"
 
 [tool.pixi.feature.test.dependencies]
 hypothesis = ">=6.152.1,<7"
-pytest = ">=9.0.3,<10"
+pytest = ">=8.0,<9"
 pytest-cases = ">=3.10.1,<4"
 pytest-cov = ">=7.1.0,<8"
 pytest-mock = ">=3.15.1,<4"

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     rioxarray22: rioxarray>=0.22.0
     shapely212: shapely>=2.1.2
     zarr316: zarr>=3.1.6
-    pytest>=8.0
+    pytest>=8.0,<9
     hypothesis>=6.0
 extras =
     test
@@ -43,7 +43,7 @@ deps=
     rioxarray~=0.22.0
     shapely~=2.1.2
     zarr~=3.1.6
-    pytest>=8.0
+    pytest~=8.0
     hypothesis>=6.0
 
 [testenv:latest]


### PR DESCRIPTION
Without diagonal traversal when switching routing options, paths would never switch is the areas are mutually exclusive. this PR adds ability to both traverse cells and swap routing layers at the same time.

Along with this there should be minor performance improvements around data I/O