### PR TITLE
Combine actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,8 @@ updates:
     github-actions:
       patterns:
         - "*"
+  commit-message:
+    prefix: "ci"
   labels:
     - "chore"
     - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,10 @@ updates:
     interval: weekly
     day: monday
   open-pull-requests-limit: 10
+  groups:
+    github-actions:
+      patterns:
+        - "*"
   labels:
     - "chore"
     - "dependencies"


### PR DESCRIPTION
Whenever there are multiple CI updates, this should combine them in a single PR. As it is today, it polutes too much the history.